### PR TITLE
Use current directory for Kernel folder copy, add ISO creation steps to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ Kernel Extraction
   menu option) and then open "Essentials.pkg". Extract the folder & file
   (Kernels/kernel) located at /System/Library/Kernels/kernel location.
 
+ISO Creation
+------------
+
+* After extracting the Kernels folder, place it in the same directory as the iso creation script.
+
+* Run the ISO creation script, making sure to use 'sudo' if possible.
+
+* Copy the ISO from your Mac to your KVM machine.
+
 Enoch Bootloader
 ----------------
 

--- a/create_osx_install_iso.sh
+++ b/create_osx_install_iso.sh
@@ -489,7 +489,7 @@ stage_start "Copying BaseSystem.dmg to writeable image"
 #rsync -aIWEh --cache --progress "$OSX_inst_base_dmg" "$OSX_inst_img_rw_mnt/" || exit_with_error "Copying BaseSystem.dmg failed"
 cp -p "$OSX_inst_base_dmg" "$OSX_inst_img_rw_mnt/" || exit_with_error "Copying BaseSystem.dmg failed"
 cp -p "${OSX_inst_base_dmg%.dmg}.chunklist" "$OSX_inst_img_rw_mnt/" || exit_with_error "Copying BaseSystem.chunklist failed"
-cp -R ~/Kernels "$OSX_inst_img_rw_mnt/System/Library/"  # this is the only tweak we have made in the upstream version!
+cp -R "$work_dir/Kernels" "$OSX_inst_img_rw_mnt/System/Library/"  # this is the only tweak we have made in the upstream version!
 stage_end_ok
 
 stage_start "Replacing Packages symlink with real files"


### PR DESCRIPTION
I ran into a 'cp' error when trying the script myself and had to look and see that it was hard coded to look into the home directory. I changed it in the script to the cwd and added documentation to the README.

It would be nice to add in the future a check to see if the Kernels folder exists.