### PR TITLE
libvirt XML configuration for High Sierra

### DIFF
--- a/macOS-HS-libvirt.xml
+++ b/macOS-HS-libvirt.xml
@@ -1,0 +1,139 @@
+<!--
+	macos High Sierra libvirt XML configuration.
+	You may hot-redirect USB with ease from GNOME Boxes and other goodies.
+
+	To install this file, you may place it at ~/.config/libvirt/qemu/
+	and run: virsh define --file macos-high-sierra.xml --validate.
+
+	This configuration has been tested in Fedora 27 with stock QEMU-KVM.
+	Move/rename images and loader/nvmram files and paths as you wish. 
+	Don't forget to replace CHANGEME with your values.
+	Replace gnome-boxes path with libvirt path if you don't use it.
+	Adjust memory and currentMemory to 3145728 if you want only 3 GiB.
+	Consider removing some cpu features if your hardware lacks suport.
+	Replace spice with vnc if you prefer it.
+	Current network configuration is a local bridge (192.157.12x.x).
+	Change it to if you prefer a public bridge instead:
+		Change interface to <interface type='user'>
+		and remove the <source bridge='virbr0'/>
+		Or use virt-manager to edit this line instead of virsh edit.
+-->
+<domain type='kvm' xmlns:qemu='http://libvirt.org/schemas/domain/qemu/1.0'>
+  <name>macos-high-sierra</name>
+  <uuid>2aca0dd6-cec9-4717-9ab2-0b7b13d111c3</uuid>
+  <title>macOS High Sierra</title>
+  <memory unit='KiB'>4194304</memory>
+  <currentMemory unit='KiB'>4194304</currentMemory>
+  <vcpu placement='static'>4</vcpu>
+  <os>
+    <type arch='x86_64' machine='pc-q35-2.10'>hvm</type>
+    <loader readonly='yes' type='pflash'>/home/CHANGEME/.local/share/gnome-boxes/images/OVMF_CODE.fd</loader>
+    <nvram>/home/CHANGEME/.local/share/gnome-boxes/images/OVMF_VARS.fd</nvram>
+  </os>
+  <features>
+    <acpi/>
+    <kvm>
+      <hidden state='on'/>
+    </kvm>
+  </features>
+  <cpu mode='custom' match='exact' check='full'>
+    <model fallback='forbid'>Penryn</model>
+    <vendor>GenuineIntel</vendor>
+    <feature policy='require' name='vme'/>
+    <feature policy='require' name='x2apic'/>
+    <feature policy='require' name='hypervisor'/>
+    <feature policy='require' name='invtsc'/>
+    <feature policy='require' name='aes'/>
+    <feature policy='require' name='xsave'/>
+    <feature policy='require' name='avx'/>
+    <feature policy='require' name='xsaveopt'/>
+    <feature policy='require' name='avx2'/>
+    <feature policy='require' name='smep'/>
+  </cpu>
+  <clock offset='utc'/>
+  <on_poweroff>destroy</on_poweroff>
+  <on_reboot>restart</on_reboot>
+  <on_crash>restart</on_crash>
+  <devices>
+    <emulator>/usr/bin/qemu-kvm</emulator>
+    <disk type='file' device='disk'>
+      <driver name='qemu' type='qcow2' cache='writeback'/>
+      <source file='/home/CHANGEME/.local/share/gnome-boxes/images/macos-high-sierra.qcow2'/>
+      <target dev='sda' bus='sata'/>
+      <boot order='2'/>
+      <address type='drive' controller='0' bus='0' target='0' unit='0'/>
+    </disk>
+    <disk type='file' device='disk'>
+      <driver name='qemu' type='qcow2' cache='writeback'/>
+      <source file='/home/CHANGEME/.local/share/gnome-boxes/images/clover.qcow2'/>
+      <target dev='sdb' bus='sata'/>
+      <boot order='1'/>
+      <address type='drive' controller='0' bus='0' target='0' unit='1'/>
+    </disk>
+    <controller type='sata' index='0'>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x1f' function='0x2'/>
+    </controller>
+    <controller type='pci' index='0' model='pcie-root'/>
+    <controller type='pci' index='1' model='dmi-to-pci-bridge'>
+      <model name='i82801b11-bridge'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x1e' function='0x0'/>
+    </controller>
+    <controller type='pci' index='2' model='pci-bridge'>
+      <model name='pci-bridge'/>
+      <target chassisNr='2'/>
+      <address type='pci' domain='0x0000' bus='0x01' slot='0x00' function='0x0'/>
+    </controller>
+    <controller type='usb' index='0' model='ich9-ehci1'>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x1d' function='0x7'/>
+    </controller>
+    <controller type='usb' index='0' model='ich9-uhci1'>
+      <master startport='0'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x1d' function='0x0' multifunction='on'/>
+    </controller>
+    <controller type='usb' index='0' model='ich9-uhci2'>
+      <master startport='2'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x1d' function='0x1'/>
+    </controller>
+    <controller type='usb' index='0' model='ich9-uhci3'>
+      <master startport='4'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x1d' function='0x2'/>
+    </controller>
+    <interface type='bridge'>
+      <mac address='52:54:00:8e:e2:66'/>
+      <source bridge='virbr0'/>
+      <target dev='tap0'/>
+      <model type='e1000-82545em'/>
+      <address type='pci' domain='0x0000' bus='0x02' slot='0x02' function='0x0'/>
+    </interface>
+    <input type='keyboard' bus='usb'>
+      <address type='usb' bus='0' port='2'/>
+    </input>
+    <input type='mouse' bus='ps2'/>
+    <input type='tablet' bus='usb'>
+      <address type='usb' bus='0' port='3'/>
+    </input>
+    <input type='keyboard' bus='ps2'/>
+    <graphics type='spice'>
+      <listen type='none'/>
+    </graphics>
+    <sound model='ich9'>
+      <address type='pci' domain='0x0000' bus='0x02' slot='0x01' function='0x0'/>
+    </sound>
+    <video>
+      <model type='qxl' ram='65536' vram='65536' vgamem='16384' heads='1' primary='yes'/>
+      <address type='pci' domain='0x0000' bus='0x00' slot='0x01' function='0x0'/>
+    </video>
+    <redirdev bus='usb' type='spicevmc'>
+      <address type='usb' bus='0' port='5'/>
+    </redirdev>
+    <hub type='usb'>
+      <address type='usb' bus='0' port='1'/>
+    </hub>
+    <memballoon model='none'/>
+  </devices>
+  <seclabel type='dynamic' model='selinux' relabel='yes'/>
+  <qemu:commandline>
+    <qemu:arg value='-device'/>
+    <qemu:arg value='isa-applesmc,osk=ourhardworkbythesewordsguardedpleasedontsteal(c)AppleComputerInc'/>
+  </qemu:commandline>
+</domain>


### PR DESCRIPTION
Hi,

Due to popular demand, here is a working XML configuration file example for macOS High Sierra. Includes some few instructions in the comment. Feel free to amend it in your own push and close this PR.

I've tested it in Fedora 27 with stock qemu-kvm 2.10.1, so I've changed machine to pc-q35-2.10 for a bit newer one and still works nicely so far. It's tested with your provided OVMF_CODE-pure-efi.fd and OVMF_VARS-pure-efi-1024x768.fd only.

The main motivation of having libvirt XML file is the pretty straightforward USB redirection to the guest, allowing to use it without dealing with system session, root, changing permissions, selinux and such. SPICE protocol for screen hypervisor also feels a bit faster refresh, mostly noticeable while shaking windows with mouse pointer. VNC also works as expected if preferred.

The settings provided are not quite polished, maybe some libvirt and KVM modern defaults make some features redundant, however.

Enjoy, regards.