### PR TITLE
Fedora 27 and i7-5820k clock issues

### DIFF
--- a/HighSierra/README.md
+++ b/HighSierra/README.md
@@ -9,6 +9,8 @@ Known to work on:
 
 * Fedora 25 running on i7-6600U CPU.
 
+* Fedora 27 running on i7-5820k CPU.
+
 * Ubuntu 17.04 running on i5-6500 CPU.
 
 * Gentoo (October-2017) running on AMD FX-8320 CPU with AMD RX 470 GPU
@@ -17,6 +19,8 @@ Known to work on:
 Tested with QEMU >= 2.10 (with an out-of-tree patch) and Linux 4.10.x / 4.12.x.
 A CPU with SSE4.1 support is required for macOS High Sierra. Intel VT-x / AMD
 SVM is required.
+
+Fedora 27 tested with QEMU 2.0.1-2.fc27 (current Fedora repository version as of 27-Jan-2018), kernel 4.14.14.
 
 
 ### Installation Preparation

--- a/macOS-HS-libvirt.xml
+++ b/macOS-HS-libvirt.xml
@@ -25,6 +25,14 @@
 		Change interface to <interface type='user'>
 		and remove the <source bridge='virbr0'/>
 		Or use virt-manager to edit this line instead of virsh edit.
+
+		Note: Default configuration caused severe clock problems
+		under Fedora 27 w/ i7-5820k. This is because Darwin uses
+		tsc (time since last tick) for time, and for me did not
+		fall back to rtc in the event of a clock mismatch with
+		libvirt's default time source. Therefore we must explicitly
+		give the clock a tsc timer for kvm to pass to the guest.
+		See comments on the <kvm> and <clock> attributes.
 -->
 <domain type='kvm' xmlns:qemu='http://libvirt.org/schemas/domain/qemu/1.0'>
   <name>macos-high-sierra</name>
@@ -40,6 +48,7 @@
   </os>
   <features>
     <acpi/>
+<!-- Note: On Fedora 27 w/ an i7-5820k CPU and repository QEMU version as of 27-Jan-2018, the guest experienced severe clock issues. If you encounter these issues, try changing this to <hidden state ='off'--> 
     <kvm>
       <hidden state='on'/>
     </kvm>
@@ -58,6 +67,15 @@
     <feature policy='require' name='avx2'/>
     <feature policy='require' name='smep'/>
   </cpu>
+<!-- Note: To resolve clock issues experienced on Fedora 27 as described at top of file,
+     we need to add a timer. Replace the clock offset line with 
+
+     <clock offset='utc'/>
+       <timer name='tsc'/>
+     </clock>
+
+     Please remember to also change the kvm hidden state as well, as described above.
+-->
   <clock offset='utc'/>
   <on_poweroff>destroy</on_poweroff>
   <on_reboot>restart</on_reboot>


### PR DESCRIPTION
Adds Fedora 27 w/ kernel 4.14.14 as a successful host OS and details clock issues encountered with i7-5820k CPU under this configuration. Adds description of clock issue to comment at top of macOS-HS-libvirt.xml and commented-out modifications to the specification which resolve the clock issue, namely changing the kvm hidden state to off and adding a tsc timer to the clock, as Darwin uses tsc for time keeping. Result is High Sierra working perfectly as guest using virt-manager/GNOME Boxes.

Note that the clock issue was not encountered using raw qemu-kvm with the startup scripts, the root issue is likely libvirt clock defaults.