### PR TITLE
increase Mojave disk image size

### DIFF
--- a/Mojave/create_iso_mojave.sh
+++ b/Mojave/create_iso_mojave.sh
@@ -4,7 +4,7 @@
 set -e
 
 # Borrrowed from multiple internet sources
-hdiutil create -o ~/Desktop/Mojave.cdr -size 5800m -layout SPUD -fs HFS+J
+hdiutil create -o ~/Desktop/Mojave.cdr -size 6g -layout SPUD -fs HFS+J
 hdiutil attach ~/Desktop/Mojave.cdr.dmg -noverify -mountpoint /Volumes/install_build
 sudo /Applications/Install\ macOS\ Mojave\ Beta.app/Contents/Resources/createinstallmedia --volume /Volumes/install_build --nointeraction
 hdiutil detach "/Volumes/Install macOS Mojave Beta"


### PR DESCRIPTION
When creating `.iso` image for latest Mojave version I encountered to an error:
```
Error: Error Domain=NSCocoaErrorDomain Code=512 ““InstallESD.dmg” couldn’t be copied to “SharedSupport”.” UserInfo={NSSourceFilePathErrorKey=/Applications/Install macOS Mojave Beta.app/Contents/SharedSupport/InstallESD.dmg, NSUserStringVariant=(
Copy
), NSDestinationFilePath=/Volumes/Install macOS Mojave Beta 1/Install macOS Mojave Beta.app/Contents/SharedSupport/InstallESD.dmg, NSFilePath=/Applications/Install macOS Mojave Beta.app/Contents/SharedSupport/InstallESD.dmg, NSUnderlyingError=0x7f99aef7eaf0 {Error Domain=NSPOSIXErrorDomain Code=34 “Result too large”}}The copy of the installer app failed.
```

increasing disk image size from `5800m` to `6g` in the script fixed the issue.