### PR TITLE
Updating readme so filename matches

### DIFF
--- a/HighSierra/README.md
+++ b/HighSierra/README.md
@@ -40,7 +40,7 @@ required.
   git clone https://github.com/kholia/OSX-KVM.git
   ```
 
-* Run the ISO creation script `create_iso_highsierra.sh` included in this
+* Run the ISO creation script `create_install_iso.sh` included in this
   folder. Run it with `sudo`.
 
 * Copy the generated ISO image from your Mac's Desktop to your QEMU/KVM machine.


### PR DESCRIPTION
This file doesn't exist in master, I am making an assumption here that this has been renames to `create_install_iso.sh`

Though, I may be wrong, but I feel it is good to let you know.

Cheers!