### PR TITLE
Notes on vmxnet3 adapter

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -39,3 +39,5 @@
 * Jan Kuri (jkuri) - Mojave ISO creation fixes
 
 * Mike Hardy (mikehardy) - Network documentation improvements
+
+* pickled_monkey - Information on vmxnet3

--- a/networking-qemu-kvm-howto.txt
+++ b/networking-qemu-kvm-howto.txt
@@ -10,19 +10,36 @@ slowest and is not visible via the outside network, but requires no host-side
 setup, so it's perfect if you just want internet but don't care about latency
 or about connecting to the VM from an external source.
 
-The problem that we run into here is that OS X is nitpicky about what emulated
-networking devices it is willing to accept, so we need to specify the network
-configuration to use the e1000 emulated card with SLiRP networking.
-
 In order to do this, change the line in your qemu-system-x86_64 command (found
 in boot-macOS.sh) to the following:
 
--netdev user,id=net0 -device e1000-82545em,netdev=net0,id=net0,mac=52:54:00:c9:18:27 \
+-netdev user,id=net0 -device network_adapter,netdev=net0,id=net0,mac=52:54:00:c9:18:27 \
 
-No further setup is required; your internet should Just Werk™ in your virtual machine!
+Once you set network_adapter to the perfered adapter, no further setup is required; your
+internet should Just Werk™ in your virtual machine!
 
 For further information on detailed configuration options, see QEMU's
 documentation on networking ( http://wiki.qemu.org/Documentation/Networking )
+
+--------------
+e1000-82545em
+--------------
+
+The problem that we run into here is that OS X is nitpicky about what emulated
+networking devices it is willing to accept. The e1000-82545em is a known adapter
+that can be used on pretty much any version of MacOS.
+
+To use this adapter, replace network_adapter with e1000-82545em
+
+--------
+vmxnet3
+--------
+
+An alternative solution to e1000 is to use vmxnet3 instead. Unlike the e1000, vmxnet3 is
+a paravirtualized NIC, which can allow for better performance (in theory). The only catch
+is that the you need to have a recent version of MacOS (10.11 or later).
+
+To use this adapter, replace network_adapter with vmxnet3
 
 -----------------------------------
 Tap Networking (Better Performance)


### PR DESCRIPTION
Hello kholia,

The current pull request is currently not ready to be merged, but I thought I would submit a pull request so that you can give feedback on my edits. I am not sure how I should word/organize the information. 

The network document file never talks about `vmxnet3`, despite it being mentioned [in one of the scripts](https://github.com/kholia/OSX-KVM/blob/master/boot-macOS.sh#L15). Being inspired by pickled_monkey's Reddit comment on vmxnet3, I thought it would be a good idea to bring awareness to the alternative adapter.

Once it is ready to merge, I can squash my commits. Let me know what you think!

(Personal) Notes: 
[VMXNET3 Driver included in El Capitan](https://www.virtuallyghetto.com/2016/10/vmxnet3-driver-now-included-in-mac-os-x-10-11-el-capitan.html)
[pickled_monkey's notes on vmxnet3](https://www.reddit.com/r/hackintosh/comments/7q8yxh/high_sierra_inside_linux_with_pci_passthrough/dst5raj/)