### PR TITLE
[mojave] BaseSystem.dmg can be located besides InstallESD.dmg

### DIFF
--- a/create_install_iso.sh
+++ b/create_install_iso.sh
@@ -338,7 +338,11 @@ stage_start_nl "Mounting InstallESD.dmg"
 OSX_inst_inst_dmg="$OSX_inst_app"'/Contents/SharedSupport/InstallESD.dmg'
 OSX_inst_inst_dmg_mnt="$tmp_dir/InstallESD_dmg_mnt"
 hdiutil attach "$OSX_inst_inst_dmg" -kernel -readonly -nobrowse ${ver_opt+-noverify} -mountpoint "$OSX_inst_inst_dmg_mnt" || exit_with_error "Can't mount installation image. Reboot recommended before retry."
-OSX_inst_base_dmg="$OSX_inst_inst_dmg_mnt/BaseSystem.dmg" || exit_with_error
+if [ -f "$OSX_inst_app"'/Contents/SharedSupport/BaseSystem.dmg' ]; then
+    OSX_inst_base_dmg="$OSX_inst_app"'/Contents/SharedSupport/BaseSystem.dmg'
+else
+    OSX_inst_base_dmg="$OSX_inst_inst_dmg_mnt/BaseSystem.dmg" || exit_with_error
+fi
 stage_end_ok "Mounting succeed"
 
 stage_start "Calculating required image size"


### PR DESCRIPTION
This fix ensures base system's new place in latest Mojave then falls back to look into mounted install image.
Actually, `SharedSupport` folder has the following files,

```bash
Monarakh:OSX-KVM segabor$ ls -l /Applications/Install\ macOS\ Mojave.app/Contents/SharedSupport/
total 11711136
-rw-r--r--  1 root  wheel         328 Nov 15 08:39 AppleDiagnostics.chunklist
-rw-r--r--@ 1 root  wheel     2902655 Nov 15 08:39 AppleDiagnostics.dmg
-rw-r--r--  1 root  wheel        1948 Nov 15 08:39 BaseSystem.chunklist
-rw-r--r--@ 1 root  wheel   482126050 Nov 15 08:39 BaseSystem.dmg
-rw-r--r--  1 root  wheel  5502930751 Nov 15 08:38 InstallESD.dmg
-rw-r--r--  1 root  wheel        1386 Oct 24 09:26 InstallInfo.plist
```
