### PR TITLE
Pass paths via command-line arguments to create_iso_* scripts

### DIFF
--- a/HighSierra/create_iso_highsierra.sh
+++ b/HighSierra/create_iso_highsierra.sh
@@ -3,15 +3,29 @@
 # Bail at first High Sierra ISO creation error
 set -e
 
-if [ "$#" -ne 2 ]
-then
-    echo "Illegal number of parameters"
-    echo "Usage: create_iso_highsierra.sh <path/to/install_app.app> <path/to/output_iso_file.iso>"
-    exit 1
+display_help() {
+    echo "Usage: $(basename $0) [-h] [<path/to/install_app.app> <path/to/output_iso_file.iso>]"
+    exit 0
+}
+
+if [ "$1" == "-h" ] ; then
+    display_help
 fi
 
-in_path=$1
-iso_path=$2
+if [ "$#" -eq 2 ]
+then
+    in_path=$1
+    iso_path=$2
+elif [ "$#" -eq 0 ]
+then
+    in_path=/Applications/Install\ macOS\ High\ Sierra.app
+    iso_path=~/Desktop/HighSierra.iso
+    echo "Using default paths:"
+    echo "Install app: $in_path"
+    echo "Output disk: $iso_path"
+else
+    display_help
+fi
 
 # Borrrowed from multiple internet sources
 hdiutil create -o "$iso_path.cdr" -size 5600m -layout SPUD -fs HFS+J

--- a/HighSierra/create_iso_highsierra.sh
+++ b/HighSierra/create_iso_highsierra.sh
@@ -3,11 +3,24 @@
 # Bail at first High Sierra ISO creation error
 set -e
 
+if [ "$#" -ne 2 ]
+then
+    echo "Illegal number of parameters"
+    echo "Usage: create_iso_highsierra.sh <path/to/install_app.app> <path/to/output_iso_file.iso>"
+    exit 1
+fi
+
+in_path=$1
+iso_path=$2
+
 # Borrrowed from multiple internet sources
-hdiutil create -o ~/Desktop/HighSierra.cdr -size 5600m -layout SPUD -fs HFS+J
-hdiutil attach ~/Desktop/HighSierra.cdr.dmg -noverify -mountpoint /Volumes/install_build
-sudo /Applications/Install\ macOS\ High\ Sierra.app/Contents/Resources/createinstallmedia --volume /Volumes/install_build --nointeraction
+hdiutil create -o "$iso_path.cdr" -size 5600m -layout SPUD -fs HFS+J
+hdiutil attach "$iso_path.cdr.dmg" -noverify -mountpoint /Volumes/install_build
+sudo "$in_path/Contents/Resources/createinstallmedia" --volume /Volumes/install_build --nointeraction
 hdiutil detach "/Volumes/Install macOS High Sierra"
-hdiutil convert ~/Desktop/HighSierra.cdr.dmg -format UDTO -o ~/Desktop/HighSierra.iso
-mv ~/Desktop/HighSierra.iso.cdr ~/Desktop/HighSierra.iso
-rm ~/Desktop/HighSierra.cdr.dmg
+
+# hdiutil convert will actually put the output file at $iso_path.cdr
+hdiutil convert "$iso_path.cdr.dmg" -format UDTO -o "$iso_path"
+
+mv "$iso_path.cdr" "$iso_path"
+rm "$iso_path.cdr.dmg"

--- a/Mojave/create_iso_mojave.sh
+++ b/Mojave/create_iso_mojave.sh
@@ -3,11 +3,24 @@
 # Bail at first ISO creation error
 set -e
 
+if [ "$#" -ne 2 ]
+then
+    echo "Illegal number of parameters"
+    echo "Usage: create_iso_mojave.sh <path/to/install_app.app> <path/to/output_iso_file.iso>"
+    exit 1
+fi
+
+in_path=$1
+iso_path=$2
+
 # Borrrowed from multiple internet sources
-hdiutil create -o ~/Desktop/Mojave.cdr -size 6g -layout SPUD -fs HFS+J
-hdiutil attach ~/Desktop/Mojave.cdr.dmg -noverify -mountpoint /Volumes/install_build
-sudo /Applications/Install\ macOS\ Mojave.app/Contents/Resources/createinstallmedia --volume /Volumes/install_build --nointeraction
+hdiutil create -o "$iso_path.cdr" -size 6g -layout SPUD -fs HFS+J
+hdiutil attach "$iso_path.cdr.dmg" -noverify -mountpoint /Volumes/install_build
+sudo "$in_path/Contents/Resources/createinstallmedia" --volume /Volumes/install_build --nointeraction
 hdiutil detach "/Volumes/Install macOS Mojave"
-hdiutil convert ~/Desktop/Mojave.cdr.dmg -format UDTO -o ~/Desktop/Mojave.iso
-mv ~/Desktop/Mojave.iso.cdr ~/Desktop/Mojave.iso
-rm ~/Desktop/Mojave.cdr.dmg
+
+# hdiutil convert will actually put the output file at $iso_path.cdr
+hdiutil convert "$iso_path.cdr.dmg" -format UDTO -o "$iso_path"
+
+mv "$iso_path.cdr" "$iso_path"
+rm "$iso_path.cdr.dmg"

--- a/Mojave/create_iso_mojave.sh
+++ b/Mojave/create_iso_mojave.sh
@@ -3,15 +3,29 @@
 # Bail at first ISO creation error
 set -e
 
-if [ "$#" -ne 2 ]
-then
-    echo "Illegal number of parameters"
-    echo "Usage: create_iso_mojave.sh <path/to/install_app.app> <path/to/output_iso_file.iso>"
-    exit 1
+display_help() {
+    echo "Usage: $(basename $0) [-h] [<path/to/install_app.app> <path/to/output_iso_file.iso>]"
+    exit 0
+}
+
+if [ "$1" == "-h" ] ; then
+    display_help
 fi
 
-in_path=$1
-iso_path=$2
+if [ "$#" -eq 2 ]
+then
+    in_path=$1
+    iso_path=$2
+elif [ "$#" -eq 0 ]
+then
+    in_path=/Applications/Install\ macOS\ Mojave.app
+    iso_path=~/Desktop/Mojave.iso
+    echo "Using default paths:"
+    echo "Install app: $in_path"
+    echo "Output disk: $iso_path"
+else
+    display_help
+fi
 
 # Borrrowed from multiple internet sources
 hdiutil create -o "$iso_path.cdr" -size 6g -layout SPUD -fs HFS+J


### PR DESCRIPTION
This makes life for people dealing with multiple OSX versions much easier.