### PR TITLE
Update Mojave readme: disable system sleep

### DIFF
--- a/Mojave/README.md
+++ b/Mojave/README.md
@@ -5,7 +5,9 @@ only difference is that Mojave now requires CPU instructions that were
 introduced with Nehalem, so you will need to add CPU feature flags for ssse3,
 sse4.2, and popcnt to avoid Illegal Instruction crashes in the graphics
 subsystem after boot is complete (causing the top menu bar to flash on and off,
-and Finder to crash on open).
+and Finder to crash on open). You may also need to disable system sleep in
+Mojave’s Energy Saver settings because that a Mojave system will halt and not
+respond to any wake-ups after the system sleep.
 
 Tested with Clover 4674.
 


### PR DESCRIPTION
I've successfully installed Mojave in KVM with the help of #92, yet I found that my Mojave system will be dead after a system sleep. After reading this [article](https://www.nicksherlock.com/2018/06/installing-macos-mojave-on-proxmox/) I found that it also mentioned the sleep management problem. 
I think it's better to suggest turning off system sleep in Mojave's Energy Saver settings in Mojave's README document.