### PR TITLE
Updated instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Phenom II X3 720 does not. Ryzen processors work just fine.
 
   sudo brctl addif virbr0 tap0
   ```
+Note for Archlinux users: virbr0 autogeneration has been [deactivated](https://bugs.archlinux.org/task/50693)
 
 * Now you are ready to install macOS 🚀
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Phenom II X3 720 does not. Ryzen processors work just fine.
 
   sudo brctl addif virbr0 tap0
   ```
-Note for Archlinux users: virbr0 autogeneration has been [deactivated](https://bugs.archlinux.org/task/50693)
+  If virbr0 is not present on your system, it has been [deactivated](https://bugs.archlinux.org/task/50693). To enable it, give `virsh net-autostart default` and reboot your system.
 
 * Now you are ready to install macOS 🚀
 

--- a/README.md
+++ b/README.md
@@ -94,9 +94,7 @@ Phenom II X3 720 does not. Ryzen processors work just fine.
 
   ```
   sudo ip tuntap add dev tap0 mode tap
-
   sudo ip link set tap0 up promisc on
-
   sudo brctl addif virbr0 tap0
   ```
   If virbr0 is not present on your system, it has been [deactivated](https://bugs.archlinux.org/task/50693). To enable it, give `virsh net-autostart default` and reboot your system.

--- a/notes.md
+++ b/notes.md
@@ -158,14 +158,17 @@ is provided for this unmaintained project!
 
 * Add `-vga vmware` to QEMU parameters in boot-macOS.sh.
 
+#### Chameleon
 * Add the following to `/Extra/org.chameleon.Boot.plist` file.
 
   ```
   <key>Kernel Flags</key>
   <string>vmw_options_fb=0x06</string>
   ```
-
 Thanks to Zhang Tong and Kfir Ozer for finding this.
+
+#### Clover
+* Add `wmv_option_fb=0x06` to the `<string>` tag of the `Arguments` key of the `config.plist` you use when generating the `CloverNG.qcow2`.
 
 See `UEFI/README.md` for GPU passthrough notes.
 


### PR DESCRIPTION
I have added notes for when virbr0 is not enabled on the host system and to enable hardware acceleration by default with clover bootloader.