### PR TITLE
Replace `brctl`

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,8 @@ Phenom II X3 720 does not. Ryzen processors work just fine.
   ```
   sudo ip tuntap add dev tap0 mode tap
   sudo ip link set tap0 up promisc on
-  sudo brctl addif virbr0 tap0
+  sudo ip link set dev virbr0 up
+  sudo ip link set dev tap0 master virbr0
   ```
 
   Note: If `virbr0` network interface is not present on your system, it may
@@ -170,7 +171,8 @@ Phenom II X3 720 does not. Ryzen processors work just fine.
 
   sudo ip tuntap add dev tap0 mode tap
   sudo ip link set tap0 up promisc on
-  sudo brctl addif virbr0 tap0
+  sudo ip link set dev virbr0 up
+  sudo ip link set dev tap0 master virbr0
   ```
 
   This has been enough for me so far.


### PR DESCRIPTION
Ubuntu 19.04 does not include `brctl` anymore, but `ip` works just as well