### PR TITLE
iPhone into VM via PCIe USB card passthrough

### DIFF
--- a/notes.md
+++ b/notes.md
@@ -171,7 +171,7 @@ $ make clean; make; make install
 ```
 
 ### Connect iPhone / iPad to macOS guest
-
+Passthrough a PCIe USB card to the virtual machine to be able to connect iDevices to it
 Some folks are using https://www.virtualhere.com/ to connect iPhone / iPad to
 the macOS guest.
 


### PR DESCRIPTION
I'm using a PCIe USB card to connect an iPhone to the virtual machine.
Tested building a react native project directly into the iPhone. Works flawlessly.