### PR TITLE
Increase Catalina disk image size

### DIFF
--- a/Catalina/create_iso_catalina.sh
+++ b/Catalina/create_iso_catalina.sh
@@ -28,7 +28,7 @@ else
 fi
 
 # Borrrowed from multiple internet sources
-hdiutil create -o "$iso_path.cdr" -size 7g -layout SPUD -fs HFS+J
+hdiutil create -o "$iso_path.cdr" -size 9g -layout SPUD -fs HFS+J
 hdiutil attach "$iso_path.cdr.dmg" -noverify -mountpoint /Volumes/install_build
 sudo "$in_path/Contents/Resources/createinstallmedia" --volume /Volumes/install_build --nointeraction
 hdiutil detach "/Volumes/Install macOS Catalina"


### PR DESCRIPTION
When creating .iso image for Catalina:

```
Error: Error Domain=NSCocoaErrorDomain Code=512 "“InstallESD.dmg” couldn’t be copied to “SharedSupport”." UserInfo={NSSourceFilePathErrorKey=/Applications/Install macOS Catalina.app/Contents/SharedSupport/InstallESD.dmg, NSUserStringVariant=(
    Copy
), NSDestinationFilePath=/Volumes/Install macOS Catalina/Install macOS Catalina.app/Contents/SharedSupport/InstallESD.dmg, NSFilePath=/Applications/Install macOS Catalina.app/Contents/SharedSupport/InstallESD.dmg, NSUnderlyingError=0x7fe32c9422f0 {Error Domain=NSPOSIXErrorDomain Code=34 "Result too large"}}The copy of the installer app failed.
```

9G is enough for this image.