### PR TITLE
Improved shebang

### DIFF
--- a/fetch-macOS.py
+++ b/fetch-macOS.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python2
 # encoding: utf-8
 #
 # https://github.com/munki/macadmin-scripts/blob/master/installinstallmacos.py


### PR DESCRIPTION
Certain operating systems, such as Arch Linux, use `python3` when `/usr/bin/python` is invoked, rather than `python2`. This proposed change fixes that.

I can apply my changes to more files, if necessary.