### PR TITLE
boot-macOS-Catalina.sh: remove redundant kvm=on

### DIFF
--- a/boot-macOS-Catalina.sh
+++ b/boot-macOS-Catalina.sh
@@ -16,7 +16,7 @@ MY_OPTIONS="+pcid,+ssse3,+sse4.2,+popcnt,+avx,+aes,+xsave,+xsaveopt,check"
 OVMF="./"
 
 # qemu-system-x86_64 -enable-kvm -m 3072 -cpu Penryn,kvm=on,vendor=GenuineIntel,+invtsc,vmware-cpuid-freq=on,$MY_OPTIONS\
-qemu-system-x86_64 -enable-kvm -m 3072 -cpu Penryn,kvm=on,vendor=GenuineIntel,+invtsc,vmware-cpuid-freq=on,hypervisor=off,vmx=on,kvm=off,$MY_OPTIONS\
+qemu-system-x86_64 -enable-kvm -m 3072 -cpu Penryn,vendor=GenuineIntel,+invtsc,vmware-cpuid-freq=on,hypervisor=off,vmx=on,kvm=off,$MY_OPTIONS\
 	  -machine q35 \
 	  -smp 4,cores=2 \
 	  -usb -device usb-kbd -device usb-mouse \


### PR DESCRIPTION
It doesn't make sense to pass `kvm=on` when `kvm=off` is passed few args later.