### PR TITLE
Update Big-Sur.md

### DIFF
--- a/Big-Sur.md
+++ b/Big-Sur.md
@@ -36,7 +36,7 @@
   make
   ```
 
-- Extract `BaseSystem.dmg` from the downloaded `InstallAssistant.pkg` file (around 9 GB).
+- Extract `SharedSupport.dmg` from the downloaded `InstallAssistant.pkg` file (around 9 GB).
 
   ```
   $ ~/xar/xar/src/xar -tf InstallAssistant.pkg


### PR DESCRIPTION
- Extract `SharedSupport.dmg` from the downloaded `InstallAssistant.pkg` file (around 9 GB).