### PR TITLE
enable vmware-svga graphics for libvirt catalina

### DIFF
--- a/macOS-libvirt-Catalina.xml
+++ b/macOS-libvirt-Catalina.xml
@@ -169,6 +169,10 @@
     <input type='keyboard' bus='ps2'>
       <alias name='input3'/>
     </input>
+    <!-- We use video model none here, so we can later set video device to vmware-svga for better graphics -->
+    <video>
+      <model type='none'/>
+    </video>
     <!-- If you wanna passthrough GPU, make sure the gfx and audio are in the same bus (like 0x01) but different function (0x00 and 0x01)-->
     <!-- <hostdev mode='subsystem' type='pci' managed='yes'>
       <driver name='vfio'/>
@@ -202,6 +206,8 @@
     <qemu:arg value='isa-applesmc,osk=ourhardworkbythesewordsguardedpleasedontsteal(c)AppleComputerInc'/>
     <qemu:arg value='-smbios'/>
     <qemu:arg value='type=2'/>
+    <qemu:arg value='-device'/>
+    <qemu:arg value='vmware-svga'/>
     <qemu:arg value='-cpu'/>
     <qemu:arg value='Penryn,kvm=on,vendor=GenuineIntel,+invtsc,vmware-cpuid-freq=on,+pcid,+ssse3,+sse4.2,+popcnt,+avx,+aes,+xsave,+xsaveopt,check'/>
     <!-- <qemu:arg value='Penryn,vendor=GenuineIntel,+hypervisor,+invtsc,kvm=on,+fma,+avx,+avx2,+aes,+ssse3,+sse4_2,+popcnt,+sse4a,+bmi1,+bmi2'/> -->


### PR DESCRIPTION
## About

Enables usage of `vmware-svga` in libvirt domain for mac osx Catalina.

## Description

Currently if running osx under libvirt, default video device defaults to cirrus. This results in low resolution graphics.
Changing graphics to `vmware-svga` results in good resolution and better performance.

## Notes

libvirt has incomplete schema, where it does not allow to set `vmware-svga` (or `vmware`) as video model type. For example setting this is invalid according to schema:

```
    <video>
      <model type='vmware-svga'/>
    </video>
```

A workaround was to set video model type to none and adding `device` argument to qemu. Just removing `video` block will add default cirrus graphics and schema will again not validate, as there will be two graphics cards on same bus, instead of only one.

I know this can be patched upstream, but this is a special case, and workaround seem to work just fine for now.