### PR TITLE
Updated fetch-macOS.py with the newest Big Sur product ID

### DIFF
--- a/fetch-macOS.py
+++ b/fetch-macOS.py
@@ -401,8 +401,8 @@ def main():
     # (Temporary) Hack to fetch Big Sur
     if args.big_sur:
         products = catalog['Products']
-        # https://mrmacintosh.com/whats-new-in-macos-big-sur-11-beta-2-20a4300b/
-        product = products["001-23553-002"]
+        # Beta 3 ID:
+        product = products["001-26097"]
         workdir = "."
         ignore_cache = False
         for package in product.get('Packages', []):


### PR DESCRIPTION
The fetch-macOS.py script stopped working after Beta 3 got released. I have updated the hard-coded product ID with the one for Beta 3, and all seems well again now.