### PR TITLE
Add dependency installation in Big-Sur instructions

### DIFF
--- a/Big-Sur.md
+++ b/Big-Sur.md
@@ -20,6 +20,12 @@
   make
   ```
 
+- Install dependencies for `darling-dmg`. (The following is for Debian/Ubuntu, different distros name packages differently.)
+
+  ```
+  apt install libxml2-dev libbz2-dev libfuse-dev
+  ```
+
 - Get `darling-dmg` software.
 
   ```


### PR DESCRIPTION
While this is most likely not an exhaustive list, darling-dmg requires a couple extra development packages to be installed.

This adds a Debian/Ubuntu specific list for installing these dependencies. (In retrospect, it feels like cmake maybe should be part of that list)