### PR TITLE
Reformat Big-Sur.md and unRAID documentation

### DIFF
--- a/Big-Sur.md
+++ b/Big-Sur.md
@@ -2,83 +2,52 @@
 
 #### Note: Installation (for the most part) remains the same, except for the retrieval of the DMG file.
 
-- Fetch the `Big Sur` installer using the following command:
+- Fetch the `Big Sur` installer using the following command (as usual):
 
   ```
-  ./fetch-macOS.py --big-sur
+  ./fetch-macOS.py
   ```
 
-- Get `xar` software.
+- Unpack the download InstallAssistant.pkg file:
 
   ```
-  cd ~  # modify as needed
-
-  git clone https://github.com/VantaInc/xar.git
-
-  cd xar/xar
-
-  ./autogen.sh
-
-  make
+  sudo apt install p7zip-full -y  # install the unpacking tool
   ```
 
-- Install dependencies for `darling-dmg`. (The following is for Debian/Ubuntu, different distros name packages differently.)
-
   ```
-  apt install libxml2-dev libbz2-dev libfuse-dev cmake build-essential
+  7z e -txar InstallAssistant.pkg '*.dmg'  # extract files
   ```
 
-- Get `darling-dmg` software.
+  At the end of this step, we get the `SharedSupport.dmg` file.
+
+- Extract `BaseSystem.dmg` from this `SharedSupport.dmg` file:
 
   ```
-  cd ~  # modify as needed
-
-  git clone https://github.com/darlinghq/darling-dmg.git
-
-  cd darling-dmg
-
-  # Install required deps - RTFM please ;)
-
-  cmake .
-
-  make
-  ```
-
-- Extract `SharedSupport.dmg` from the downloaded `InstallAssistant.pkg` file (around 9 GB).
-
-  ```
-  $ ~/xar/xar/src/xar -tf InstallAssistant.pkg
-  Bom
-  Payload
-  Scripts
-  PackageInfo
-  SharedSupport.dmg
-  ```
-
-- Extract `BaseSystem.dmg` from `SharedSupport.dmg`:
-
-  ```
-  ~/xar/xar/src/xar -xf InstallAssistant.pkg
-
-  7z l SharedSupport.dmg  # This will list the files in the archive
+  7z e -tdmg SharedSupport.dmg 5.hfs  # extract support dmg
 
   mkdir ~/stuff
-  darling-dmg SharedSupport.dmg ~/stuff  # Mounts SharedSupport.dmg to ~/stuff
+  sudo mount -oloop *.hfs ~/stuff  # mount the hfs filesystem
 
-  $ 7z l ~/stuff/com_apple_MobileAsset_MacSoftwareUpdate/bab26be6be4f44f58c511a1482a0e87db9a89253.zip  # The string of letters and numbers will vary
+  7z l ~/stuff/com_apple_MobileAsset_MacSoftwareUpdate/*.zip  # list files from this zip file
   ...
-  2020-08-14 21:22:18 .....    745712482    740281200  AssetData/Restore/BaseSystem.dmg
+  2020-11-06 18:57:48 .....    652236311    646767350  AssetData/Restore/BaseSystem.md
   ```
 
-- There is the required `BaseSystem.dmg` file. To unzip it, first make sure you are in the base directory for `OSX-KVM` and then retrieve the `BaseSystem.dmg` file and convert it to a `BaseSystem.img` file.
+  There is the required `BaseSystem.dmg` file. To unzip it, first make sure you
+  are in the base directory for `OSX-KVM` and then extract the `BaseSystem.dmg`
+  file.
 
   ```
   cd ~/OSX-KVM/
 
-  7z x ~/stuff/com_apple_MobileAsset_MacSoftwareUpdate/bab26be6be4f44f58c511a1482a0e87db9a89253.zip
+  7z e ~/stuff/*MacSoftwareUpdate/*.zip AssetData/Restore/Base*.dmg
 
-  cp AssetData/Restore/BaseSystem.dmg .
+  sudo umount ~/stuff
+  ```
 
+* Convert this extracted `BaseSystem.dmg` file into the `BaseSystem.img` file.
+
+  ```
   qemu-img convert BaseSystem.dmg -O raw BaseSystem.img
   ```
 

--- a/Big-Sur.md
+++ b/Big-Sur.md
@@ -1,60 +1,40 @@
-### Big Sur - Rough Notes
+# Big Sur Installation
 
-#### Note: Installation (for the most part) remains the same, except for the retrieval of the DMG file.
+Note: Installation (for the most part) remains the same, except for the retrieval of the DMG file.
 
-- Fetch the `Big Sur` installer using the following command (as usual):
+# Install Dependencies
 
-  ```
-  ./fetch-macOS.py
-  ```
+## Fedora
+`sudo dnf install p7zip p7zip-plugins qemu git wget libguestfs-tools`
 
-- Unpack the download InstallAssistant.pkg file:
+Download and install: https://src.fedoraproject.org/rpms/uml_utilities
 
-  ```
-  sudo apt install p7zip-full -y  # install the unpacking tool
-  ```
+## Ubuntu
+`sudo apt-get install qemu uml-utilities virt-manager git wget libguestfs-tools p7zip-full -y`
 
-  ```
-  7z e -txar InstallAssistant.pkg '*.dmg'  # extract files
-  ```
+# Creating Installation Media and Disk Image
+Open terminal and copy and paste the following code blocks below each step.
+* Clone and navigate into OSX-KVM repository, make a placeholder for mounting HFS 
+  * `git clone https://github.com/kholia/OSX-KVM.git`
+  * `cd OSX-KVM && mkdir tmp`
+* Select macOS version Big Sur and download
+  * `./fetch-macOS.py` 
+* Extract and mount filesystem to `tmp`
+  * `7z e -txar InstallAssistant.pkg '*.dmg'`
+  * `7z e -tdmg SharedSupport.dmg 5.hfs`
+  * `sudo mount -oloop *.hfs tmp`
+* Extract BaseSystem.dmg and convert it to .img
+  * `7z l tmp/com_apple_MobileAsset_MacSoftwareUpdate/*.zip`
+  * `7z e tmp/*MacSoftwareUpdate/*.zip AssetData/Restore/Base*.dmg`
+  * `qemu-img convert BaseSystem.dmg -O raw BaseSystem.img`
+* Create Disk Image and Unmount (currently set at 120GB)
+  * `qemu-img create -f qcow2 mac_hdd_ng.img 120G`
+  * `sudo umount tmp`
 
-  At the end of this step, we get the `SharedSupport.dmg` file.
-
-- Extract `BaseSystem.dmg` from this `SharedSupport.dmg` file:
-
-  ```
-  7z e -tdmg SharedSupport.dmg 5.hfs  # extract support dmg
-
-  mkdir ~/stuff
-  sudo mount -oloop *.hfs ~/stuff  # mount the hfs filesystem
-
-  7z l ~/stuff/com_apple_MobileAsset_MacSoftwareUpdate/*.zip  # list files from this zip file
-  ...
-  2020-11-06 18:57:48 .....    652236311    646767350  AssetData/Restore/BaseSystem.md
-  ```
-
-  There is the required `BaseSystem.dmg` file. To unzip it, first make sure you
-  are in the base directory for `OSX-KVM` and then extract the `BaseSystem.dmg`
-  file.
-
-  ```
-  cd ~/OSX-KVM/
-
-  7z e ~/stuff/*MacSoftwareUpdate/*.zip AssetData/Restore/Base*.dmg
-
-  sudo umount ~/stuff
-  ```
-
-* Convert this extracted `BaseSystem.dmg` file into the `BaseSystem.img` file.
-
-  ```
-  qemu-img convert BaseSystem.dmg -O raw BaseSystem.img
-  ```
-
-- Follow the [main documentation](README.md#installation-preparation) as this point.
-
-- Finally, you can boot `Big Sur` using the following command:
+Finally, you can boot `Big Sur` using the following command:
 
   ```
   ./OpenCore-Boot.sh
   ```
+  
+Follow the [main documentation](README.md#installation-preparation) for more information.

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -93,3 +93,9 @@
 - ADawesomeguy - Big Sur doc enhancements
 
 - shmsh9 - Python 3.9.x support
+
+- Gelma (Andrea Gelmini) - Typo fixes
+
+- ivy-rew (Reguel) - Greatly improved Big-Sur notes
+
+- Broly1 - Greatly improved Big-Sur notes

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Phenom II X3 720 does not. Ryzen processors work just fine.
 * Install QEMU and other packages.
 
   ```
-  sudo apt-get install qemu uml-utilities virt-manager git wget libguestfs-tools -y
+  sudo apt-get install qemu uml-utilities virt-manager git wget libguestfs-tools p7zip-full -y
   ```
 
   This step may need to be adapted for your Linux distribution.
@@ -127,8 +127,11 @@ Phenom II X3 720 does not. Ryzen processors work just fine.
    9    001-36735    10.15.6  2020-08-06  macOS Catalina
   10    001-36801    10.15.6  2020-08-12  macOS Catalina
   11    001-51042    10.15.7  2020-09-24  macOS Catalina
+  12    001-57224    10.15.7  2020-10-27  macOS Catalina
+  13    001-68446    10.15.7  2020-11-11  macOS Catalina
+  14    001-79699     11.0.1  2020-11-12  macOS Big Sur
 
-  Choose a product to download (1-11): 11
+  Choose a product to download (1-14): 14
   ```
 
   Attention: Modern NVIDIA GPUs are supported on HighSierra but not on later
@@ -156,7 +159,7 @@ Phenom II X3 720 does not. Ryzen processors work just fine.
 ### Installation
 
 - CLI method (primary). Just run the `OpenCore-Boot.sh` script to start the
-  installation proces.
+  installation process.
 
   ```
   ./OpenCore-Boot.sh
@@ -205,8 +208,6 @@ look at our [notes](notes.md). We would like to resume our testing and
 documentation work around this area. Please [reach out to us](mailto:dhiru.kholia@gmail.com?subject=[GitHub]%20OSX-KVM%20Funding%20Support)
 if you are able to fund this area of work.
 
-Specifically, we are looking for an AMD RX 560/570 GPU for testing purposes.
-
 It is possible to have 'beyond-native-apple-hw' performance but it does require
 work, patience, and a bit of luck (perhaps?).
 
@@ -243,6 +244,8 @@ work, patience, and a bit of luck (perhaps?).
 
 The "secret" Apple OSK string is widely available on the Internet. It is also included in a public court document [available here](http://www.rcfp.org/sites/default/files/docs/20120105_202426_apple_sealing.pdf). I am not a lawyer but it seems that Apple's attempt(s) to get the OSK string treated as a trade secret did not work out. Due to these reasons, the OSK string is freely included in this repository.
 
+Please review the ['Legality of Hackintoshing' documentation bits from Dortania's OpenCore Install Guide](https://dortania.github.io/OpenCore-Install-Guide/why-oc.html#legality-of-hackintoshing).
+
 Gabriel Somlo also has [some thoughts](http://www.contrib.andrew.cmu.edu/~somlo/OSXKVM/) on the legal aspects involved in running macOS under QEMU/KVM.
 
 
@@ -263,4 +266,4 @@ software). Also, a long time back, I had to completely wipe my (then) brand new
 `MacBook Pro (Retina, 15-inch, Late 2013)` and install Xubuntu on it - as the
 `OS X` kernel kept crashing on it!
 
-Backstory: I was a (poor) student in Canada once and Apple made [my work on cracking Apple Keychains](https://github.com/openwall/john/blob/bleeding-jumbo/src/keychain_fmt_plug.c) a lot harder than it needed to be.
+Backstory: I was a (poor) student in Canada once and Apple made [my work on cracking Apple Keychains](https://github.com/openwall/john/blob/bleeding-jumbo/src/keychain_fmt_plug.c) a lot harder than it needed to be. This is how I got interested in Hackintosh systems.

--- a/networking-qemu-kvm-howto.txt
+++ b/networking-qemu-kvm-howto.txt
@@ -15,7 +15,7 @@ in boot-macOS.sh) to the following:
 
 -netdev user,id=net0 -device network_adapter,netdev=net0,id=net0,mac=52:54:00:c9:18:27 \
 
-Once you set network_adapter to the perfered adapter, no further setup is required; your
+Once you set network_adapter to the preferred adapter, no further setup is required; your
 internet should Just Werk™ in your virtual machine!
 
 For further information on detailed configuration options, see QEMU's

--- a/scripts/bigsur/Makefile
+++ b/scripts/bigsur/Makefile
@@ -1,0 +1,81 @@
+# Builds either a recovery image (BigSur-recovery.img) or a full installer (BigSur-full.img) for Big Sur.
+
+# To build the full installer you must run this on macOS.
+# The recovery can be built on either macOS or Linux.
+
+# For Ubuntu (or similar Linux distribution) you'll need to run this first to get the required packages:
+# sudo apt install git qemu-utils p7zip-full -y
+
+# For macOS you'll probably need to run xcode-select --install to get the commandline tools
+
+BIG_SUR_APP=/Applications/Install\ macOS\ Big\ Sur.app
+
+LINUX_TOOLS = qemu-img git
+
+OS :=
+UNAME_S := $(shell uname -s)
+
+ifeq ($(UNAME_S),Darwin)
+	OS = MACOS
+endif
+
+# If this is Linux make sure we have all our build tools available:
+ifeq ($(OS),)
+	K := $(foreach exec,$(LINUX_TOOLS),\
+			$(if $(shell which $(exec)),some string,$(error "Missing required $(exec) tool for build")))
+endif
+
+all: BigSur-recovery.img
+
+BigSur-full.img : BigSur-full.dmg
+	mv $< $@
+
+ifeq ($(OS),MACOS)
+BigSur-full.dmg : $(BIG_SUR_APP)
+	hdiutil create -o "$@" -size 14g -layout GPTSPUD -fs HFS+J
+	hdiutil attach -noverify -mountpoint /Volumes/install_build "$@"
+	sudo "$</Contents/Resources/createinstallmedia" --volume /Volumes/install_build --nointeraction
+
+	# createinstallmedia leaves a bunch of subvolumes still mounted when it exits, so we need to use -force here.
+	hdiutil detach -force "/Volumes/Install macOS Big Sur"
+else
+BigSur-full.dmg :
+	$(error "Building a full installer requires this script to be run on macOS, build BigSur-recovery.img instead")
+endif
+
+$(BIG_SUR_APP) : InstallAssistant.pkg
+	sudo installer -pkg $< -target /
+
+BigSur-recovery.img : BaseSystem.dmg
+ifeq ($(OS),MACOS)
+	hdiutil convert $< -format RdWr -o $@
+else
+	qemu-img convert $< -O raw $@
+endif
+
+ifeq ($(OS),MACOS)
+BaseSystem.dmg : SharedSupport.dmg
+	hdiutil detach -force .bigsur-package-tmp || true
+	rm -rf .bigsur-package-tmp
+	mkdir .bigsur-package-tmp
+	hdiutil attach -quiet -nobrowse -mountpoint .bigsur-package-tmp $<
+	tar -O -xf .bigsur-package-tmp/com_apple_MobileAsset_MacSoftwareUpdate/*.zip AssetData/Restore/BaseSystem.dmg > BaseSystem.dmg
+	hdiutil detach -force .bigsur-package-tmp
+	rm -rf .bigsur-package-tmp
+else
+BaseSystem.dmg : SharedSupport.dmg
+	umount .bigsur-package-tmp 2>/dev/null || true
+	rm -rf .bigsur-package-tmp 2>/dev/null
+	mkdir .bigsur-package-tmp
+
+	7z e -txar InstallAssistant.pkg '*.dmg'
+	7z e -tdmg SharedSupport.dmg 5.hfs
+	sudo mount -oloop *.hfs .bigsur-package-tmp
+	7z e .bigsur-package-tmp/*MacSoftwareUpdate/*.zip AssetData/Restore/Base*.dmg
+endif
+
+SharedSupport.dmg : InstallAssistant.pkg
+	touch $@
+
+InstallAssistant.pkg :
+	../../fetch-macOS.py --version 11.0.1

--- a/scripts/create_dmg_bigsur.sh
+++ b/scripts/create_dmg_bigsur.sh
@@ -1,38 +1,3 @@
 #!/usr/bin/env bash
 
-# Create a DMG from the Big Sur Beta 3 installer app
-
-# Bail at first DMG creation error
-set -e
-
-display_help() {
-    echo "Usage: $(basename $0) [-h] [<path/to/install_app.app> <path/to/output_dmg_file.dmg>]"
-    exit 0
-}
-
-if [ "$1" == "-h" ] ; then
-    display_help
-fi
-
-if [ "$#" -eq 2 ]
-then
-    in_path=$1
-    dmg_path=$2
-elif [ "$#" -eq 0 ]
-then
-    in_path=/Applications/Install\ macOS\ Big\ Sur\ Beta.app
-    dmg_path=~/Desktop/BigSurBeta.dmg
-    echo "Using default paths:"
-    echo "Install app: $in_path"
-    echo "Output disk: $dmg_path"
-else
-    display_help
-fi
-
-hdiutil create -o "$dmg_path" -size 14g -layout GPTSPUD -fs HFS+J
-hdiutil attach "$dmg_path" -noverify -mountpoint /Volumes/install_build
-sudo "$in_path/Contents/Resources/createinstallmedia" --volume /Volumes/install_build --nointeraction
-
-# createinstallmedia  leaves a bunch of subvolumes still mounted when it exits, so we need to use -force here.
-# This might be fixed in a later Beta release:
-hdiutil detach -force "/Volumes/Install macOS Big Sur Beta"
+cd bigsur && make


### PR DESCRIPTION
I found the resources in this repository very helpful in setting up OSX Catalina and macOS Big Sur in unRAID. In this PR I'd like to propose a slight re-ordering of content in the `Big-Sur.md` tutorial file, and share some setup steps for unRAID users (possibly transferable to other hypervisor setups). This could be advantageous for testing across different OS versions, or backing up when updating to a new beta version.

I have tested this with an AMD Ryzen 5 3600, ASUS X570-P mobo, RX 5700XT, and R9 270X on unRAID beta 6.9.0-beta35. UnRAID makes it relatively easy to deploy multiple bare metal VMs on their KVM (passthrough each of these AMD GPUs for each OSX VM to run them simultaneously), and my use case here is fast concurrent development across different OS'ses locally.

Here are the steps I've taken to make one (or more) OSX VMs on Big Sur, using the resources provided from this repository. I have made a commit for `Big-Sur.md` with the contents of the first half of this PR post, and if this documentation is helpful please let me know where to make another markdown file with unRAID steps (or as a Wiki entry).

- [Install Dependencies](#install-dependencies)
  - [Fedora](#fedora)
  - [Ubuntu](#ubuntu)
- [Creating Installation Media and Disk Image](#creating-installation-media-and-disk-image)
- [Loading into UNRAID](#loading-into-unraid)
  - [Preparing the VM](#preparing-the-vm)
  - [Starting the VM](#starting-the-vm)
  - [Misc](#misc)
  - [Resources](#resources)

# Install Dependencies

## Fedora
`sudo dnf install p7zip p7zip-plugins qemu git wget libguestfs-tools`

Download and install: https://src.fedoraproject.org/rpms/uml_utilities

## Ubuntu
`sudo apt-get install qemu uml-utilities virt-manager git wget libguestfs-tools p7zip-full -y`

# Creating Installation Media and Disk Image
Open terminal and copy and paste the following code blocks below each step.
* Clone and navigate into OSX-KVM repository, make a placeholder for mounting HFS 
  * `git clone https://github.com/kholia/OSX-KVM.git`
  * `cd OSX-KVM && mkdir tmp`
* Select macOS version Big Sur and download
  * `./fetch-macOS.py` 
* Extract and mount filesystem to `tmp`
  * `7z e -txar InstallAssistant.pkg '*.dmg'`
  * `7z e -tdmg SharedSupport.dmg 5.hfs`
  * `sudo mount -oloop *.hfs tmp`
* Extract BaseSystem.dmg and convert it to .img
  * `7z l tmp/com_apple_MobileAsset_MacSoftwareUpdate/*.zip`
  * `7z e tmp/*MacSoftwareUpdate/*.zip AssetData/Restore/Base*.dmg`
  * `qemu-img convert BaseSystem.dmg -O raw BaseSystem.img`
* Create Disk Image and Unmount
  * `qemu-img create -f qcow2 mac_hdd_ng.img 280G`
  * `sudo umount tmp`
  
# Loading into UNRAID
Note: SpaceInvaderOne has a community app called "macinabox", and it is a Docker container that can automate the entire process that creates the VM and disks. The motive behind this PR is if you want to have more control during the setup process, and possibly adding supporting documentation for other hypervisors like ESXi.

Ensure you have VM support and passthrough parameters prepared (VFIO devices, PCI controllers, VNC remote, etc.). You should also have a way of reading/writing to the appropriate locations in your unRAID server (I use Krusader).

## Preparing the VM
Below are sample instructions for setting up the VM (as long as the VM has access to these files they can go anywhere). 
* Copy these 3 files `BaseSystem.img`, `mac_hdd_ng.img` and `OSX-KVM/OpenCore-Catalina/OpenCore.qcow2` into the directory of your VM
  * ie: Into `/mnt/user/domains/BigSur` where domains is the folder of your VMs
* Create a new VM and edit the XML. Use the OSX-KVM repository's `macOS-libvirt-Catalina.xml` as a guide
  * ie: I create a VM, use the GUI to adjust the CPUs, RAM, setting the OS installation media and disk images, as well as the devices I wish to pass into the VM. Then, I go in and paste the qemu args at the bottom of the XML file.
  * Note: The opencore qcow2 file should be prioritized first, it will contain the EFI boot partition that you can modify after installation using the OpenCore Configurator
* Check that the three files' primary vDisk bus is SATA, and verify types:
  * OpenCore.qcow2 `<driver name='qemu' type='qcow2' cache='writeback'/>`
  * BaseSystem.img `<driver name='qemu' type='raw' cache='writeback'/>`
  * mac_hdd_ng.img `<driver name='qemu' type='qcow2' cache='writeback'/>`
* After successful installation you can remove the BaseSystem.img entry from your xml

## Starting the VM
* Run the VM, and select the macOS base system in the bootloader
* Once the installer boots, go into disk utility and erase the qemu drive that relatively matches the space you've allocated in the qemu-img args
  * ie: Erase the disk and use these params - APFS, GUID Partition Table
* After installation, you may need to change the NIC to vmxnet3 or e1000-82545em to login with your Apple ID or install your apps from the AppStore
* Download OpenCore Configurator and tweak settings (ie: for the RX 5700XT, the args `agdpmod=pikera` is necessary to successfully boot)

## Misc

qemu args
```
  <qemu:commandline>
    <qemu:arg value='-usb'/>
    <qemu:arg value='-device'/>
    <qemu:arg value='usb-kbd,bus=usb-bus.0'/>
    <qemu:arg value='-device'/>
    <qemu:arg value='isa-applesmc,osk=ourhardworkbythesewordsguardedpleasedontsteal(c)AppleComputerInc'/>
    <qemu:arg value='-smbios'/>
    <qemu:arg value='type=2'/>
    <qemu:arg value='-cpu'/>
    <qemu:arg value='Penryn,kvm=on,vendor=GenuineIntel,+invtsc,vmware-cpuid-freq=on,+pcid,+ssse3,+sse4.2,+popcnt,+avx,+aes,+xsave,+xsaveopt,check'/>
  </qemu:commandline>
```

## Resources

* [https://forums.unraid.net/topic/84430-hackintosh-tips-to-make-a-bare-metal-macos/](https://forums.unraid.net/topic/84430-hackintosh-tips-to-make-a-bare-metal-macos/)
* [SpaceInvaderOne: How to Easily Install macOS Catalina Mojave or HighSierra as a VM on Unraid](https://www.youtube.com/watch?v=g_jk9D2e5q0)
* [Macinabox GitHub Repository](https://github.com/SpaceinvaderOne/Macinabox)