### PR TITLE
Get the BaseSystem.dmg with macrecovery.py

### DIFF
--- a/Big-Sur.md
+++ b/Big-Sur.md
@@ -11,9 +11,7 @@
 - Unpack the download InstallAssistant.pkg file:
 
   ```
-  sudo apt install libarchive-tools -y  # install unzipper for *.pkg files
-
-  bsdtar xvf InstallAssistant.pkg  # extract files
+  7z e -txar InstallAssistant.pkg *.dmg  # extract files
   ```
 
   At the end of this step, we get the `SharedSupport.dmg` file.
@@ -21,7 +19,7 @@
 - Extract `BaseSystem.dmg` from this `SharedSupport.dmg` file:
 
   ```
-  7z x SharedSupport.dmg  # extract support dmg
+  7z e -tdmg SharedSupport.dmg 5.hfs  # extract support dmg
 
   mkdir ~/stuff
   sudo mount -oloop *.hfs ~/stuff  # mount the hfs filesystem
@@ -38,7 +36,7 @@
   ```
   cd ~/OSX-KVM/
 
-  7z x ~/stuff/com_apple_MobileAsset_MacSoftwareUpdate/*.zip AssetData/Restore/BaseSystem.dmg
+  7z e ~/stuff/*MacSoftwareUpdate/ *.zip AssetData/Restore/Base*.dmg
 
   sudo umount ~/stuff
   ```
@@ -46,7 +44,7 @@
 * Convert this extracted `BaseSystem.dmg` file into the `BaseSystem.img` file.
 
   ```
-  qemu-img convert AssetData/Restore/BaseSystem.dmg -O raw BaseSystem.img
+  qemu-img convert BaseSystem.dmg -O raw BaseSystem.img
   ```
 
 - Follow the [main documentation](README.md#installation-preparation) as this point.

--- a/Big-Sur.md
+++ b/Big-Sur.md
@@ -2,84 +2,51 @@
 
 #### Note: Installation (for the most part) remains the same, except for the retrieval of the DMG file.
 
-- Fetch the `Big Sur` installer using the following command:
+- Fetch the `Big Sur` installer using the following command (as usual):
 
   ```
-  ./fetch-macOS.py --big-sur
+  ./fetch-macOS.py
   ```
 
-- Get `xar` software.
+- Unpack the download InstallAssistant.pkg file:
 
   ```
-  cd ~  # modify as needed
+  sudo apt install libarchive-tools -y  # install unzipper for *.pkg files
 
-  git clone https://github.com/VantaInc/xar.git
-
-  cd xar/xar
-
-  ./autogen.sh
-
-  make
+  bsdtar xvf InstallAssistant.pkg  # extract files
   ```
 
-- Install dependencies for `darling-dmg`. (The following is for Debian/Ubuntu, different distros name packages differently.)
+  At the end of this step, we get the `SharedSupport.dmg` file.
+
+- Extract `BaseSystem.dmg` from this `SharedSupport.dmg` file:
 
   ```
-  apt install libxml2-dev libbz2-dev libfuse-dev cmake build-essential
-  ```
-
-- Get `darling-dmg` software.
-
-  ```
-  cd ~  # modify as needed
-
-  git clone https://github.com/darlinghq/darling-dmg.git
-
-  cd darling-dmg
-
-  # Install required deps - RTFM please ;)
-
-  cmake .
-
-  make
-  ```
-
-- Extract `SharedSupport.dmg` from the downloaded `InstallAssistant.pkg` file (around 9 GB).
-
-  ```
-  $ ~/xar/xar/src/xar -tf InstallAssistant.pkg
-  Bom
-  Payload
-  Scripts
-  PackageInfo
-  SharedSupport.dmg
-  ```
-
-- Extract `BaseSystem.dmg` from `SharedSupport.dmg`:
-
-  ```
-  ~/xar/xar/src/xar -xf InstallAssistant.pkg
-
-  7z l SharedSupport.dmg  # This will list the files in the archive
+  7z x SharedSupport.dmg  # extract support dmg
 
   mkdir ~/stuff
-  darling-dmg SharedSupport.dmg ~/stuff  # Mounts SharedSupport.dmg to ~/stuff
+  sudo mount -oloop *.hfs ~/stuff  # mount the hfs filesystem
 
-  $ 7z l ~/stuff/com_apple_MobileAsset_MacSoftwareUpdate/bab26be6be4f44f58c511a1482a0e87db9a89253.zip  # The string of letters and numbers will vary
+  7z l ~/stuff/com_apple_MobileAsset_MacSoftwareUpdate/*.zip  # list files from this zip file
   ...
-  2020-08-14 21:22:18 .....    745712482    740281200  AssetData/Restore/BaseSystem.dmg
+  2020-11-06 18:57:48 .....    652236311    646767350  AssetData/Restore/BaseSystem.md
   ```
 
-- There is the required `BaseSystem.dmg` file. To unzip it, first make sure you are in the base directory for `OSX-KVM` and then retrieve the `BaseSystem.dmg` file and convert it to a `BaseSystem.img` file.
+  There is the required `BaseSystem.dmg` file. To unzip it, first make sure you
+  are in the base directory for `OSX-KVM` and then extract the `BaseSystem.dmg`
+  file.
 
   ```
   cd ~/OSX-KVM/
 
-  7z x ~/stuff/com_apple_MobileAsset_MacSoftwareUpdate/bab26be6be4f44f58c511a1482a0e87db9a89253.zip
+  7z x ~/stuff/com_apple_MobileAsset_MacSoftwareUpdate/*.zip AssetData/Restore/BaseSystem.dmg
 
-  cp AssetData/Restore/BaseSystem.dmg .
+  sudo umount ~/stuff
+  ```
 
-  qemu-img convert BaseSystem.dmg -O raw BaseSystem.img
+* Convert this extracted `BaseSystem.dmg` file into the `BaseSystem.img` file.
+
+  ```
+  qemu-img convert AssetData/Restore/BaseSystem.dmg -O raw BaseSystem.img
   ```
 
 - Follow the [main documentation](README.md#installation-preparation) as this point.

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -93,3 +93,7 @@
 - ADawesomeguy - Big Sur doc enhancements
 
 - shmsh9 - Python 3.9.x support
+
+- Gelma (Andrea Gelmini) - Typo fixes
+
+- ivy-rew (Reguel) - Greatly improved Big-Sur notes

--- a/README.md
+++ b/README.md
@@ -127,8 +127,11 @@ Phenom II X3 720 does not. Ryzen processors work just fine.
    9    001-36735    10.15.6  2020-08-06  macOS Catalina
   10    001-36801    10.15.6  2020-08-12  macOS Catalina
   11    001-51042    10.15.7  2020-09-24  macOS Catalina
+  12    001-57224    10.15.7  2020-10-27  macOS Catalina
+  13    001-68446    10.15.7  2020-11-11  macOS Catalina
+  14    001-79699     11.0.1  2020-11-12  macOS Big Sur
 
-  Choose a product to download (1-11): 11
+  Choose a product to download (1-14): 14
   ```
 
   Attention: Modern NVIDIA GPUs are supported on HighSierra but not on later
@@ -156,7 +159,7 @@ Phenom II X3 720 does not. Ryzen processors work just fine.
 ### Installation
 
 - CLI method (primary). Just run the `OpenCore-Boot.sh` script to start the
-  installation proces.
+  installation process.
 
   ```
   ./OpenCore-Boot.sh
@@ -205,8 +208,6 @@ look at our [notes](notes.md). We would like to resume our testing and
 documentation work around this area. Please [reach out to us](mailto:dhiru.kholia@gmail.com?subject=[GitHub]%20OSX-KVM%20Funding%20Support)
 if you are able to fund this area of work.
 
-Specifically, we are looking for an AMD RX 560/570 GPU for testing purposes.
-
 It is possible to have 'beyond-native-apple-hw' performance but it does require
 work, patience, and a bit of luck (perhaps?).
 
@@ -242,6 +243,8 @@ work, patience, and a bit of luck (perhaps?).
 ### Is This Legal?
 
 The "secret" Apple OSK string is widely available on the Internet. It is also included in a public court document [available here](http://www.rcfp.org/sites/default/files/docs/20120105_202426_apple_sealing.pdf). I am not a lawyer but it seems that Apple's attempt(s) to get the OSK string treated as a trade secret did not work out. Due to these reasons, the OSK string is freely included in this repository.
+
+Please review the ['Legality of Hackintoshing' documentation bits from Dortania's OpenCore Install Guide](https://dortania.github.io/OpenCore-Install-Guide/why-oc.html#legality-of-hackintoshing).
 
 Gabriel Somlo also has [some thoughts](http://www.contrib.andrew.cmu.edu/~somlo/OSXKVM/) on the legal aspects involved in running macOS under QEMU/KVM.
 

--- a/networking-qemu-kvm-howto.txt
+++ b/networking-qemu-kvm-howto.txt
@@ -15,7 +15,7 @@ in boot-macOS.sh) to the following:
 
 -netdev user,id=net0 -device network_adapter,netdev=net0,id=net0,mac=52:54:00:c9:18:27 \
 
-Once you set network_adapter to the perfered adapter, no further setup is required; your
+Once you set network_adapter to the preferred adapter, no further setup is required; your
 internet should Just Werk™ in your virtual machine!
 
 For further information on detailed configuration options, see QEMU's

--- a/scripts/bigsur/Makefile
+++ b/scripts/bigsur/Makefile
@@ -1,0 +1,108 @@
+# Builds either a recovery image (BigSur-recovery.img) or a full installer (BigSur-full.img) for Big Sur.
+
+# To build the full installer you must run this on macOS.
+# The recovery can be built on either macOS or Linux.
+
+# For Ubuntu (or similar Linux distribution) you'll need to run this first to get the required packages:
+# sudo apt install g++ git qemu-utils libxml2-dev libssl-dev zlib1g-dev cmake libbz2-dev libfuse-dev fuse autoconf unzip
+
+# For macOS you'll probably need to run xcode-select --install to get the commandline tools
+
+BIG_SUR_APP=/Applications/Install\ macOS\ Big\ Sur.app
+
+LINUX_TOOLS = qemu-img git cmake autoconf
+
+OS :=
+UNAME_S := $(shell uname -s)
+
+ifeq ($(UNAME_S),Darwin)
+	OS = MACOS
+endif
+
+# Use systemwide xar/darling-img if available:
+XAR := $(shell which xar)
+DARLING := $(shell which darling-dmg)
+
+# Otherwise we'll build them from source:
+ifeq ($(XAR),)
+XAR = xar/xar/src/xar
+endif
+
+ifeq ($(DARLING),)
+DARLING = darling-dmg/darling-dmg
+endif
+
+# If this is Linux make sure we have all our build tools available:
+ifeq ($(OS),)
+	K := $(foreach exec,$(LINUX_TOOLS),\
+			$(if $(shell which $(exec)),some string,$(error "Missing required $(exec) tool for build")))
+endif
+
+all: BigSur-recovery.img
+
+BigSur-full.img : BigSur-full.dmg
+	mv $< $@
+
+ifeq ($(OS),MACOS)
+BigSur-full.dmg : $(BIG_SUR_APP)
+	hdiutil create -o "$@" -size 14g -layout GPTSPUD -fs HFS+J
+	hdiutil attach -noverify -mountpoint /Volumes/install_build "$@"
+	sudo "$</Contents/Resources/createinstallmedia" --volume /Volumes/install_build --nointeraction
+
+	# createinstallmedia leaves a bunch of subvolumes still mounted when it exits, so we need to use -force here.
+	hdiutil detach -force "/Volumes/Install macOS Big Sur"
+else
+BigSur-full.dmg :
+	$(error "Building a full installer requires this script to be run on macOS, build BigSur-recovery.img instead")
+endif
+
+$(BIG_SUR_APP) : InstallAssistant.pkg
+	sudo installer -pkg $< -target /
+
+BigSur-recovery.img : BaseSystem.dmg
+ifeq ($(OS),MACOS)
+	hdiutil convert $< -format RdWr -o $@
+else
+	qemu-img convert $< -O raw $@
+endif
+
+ifeq ($(OS),MACOS)
+BaseSystem.dmg : SharedSupport.dmg
+	hdiutil detach -force .bigsur-package-tmp || true
+	rm -rf .bigsur-package-tmp
+	mkdir .bigsur-package-tmp
+	hdiutil attach -quiet -nobrowse -mountpoint .bigsur-package-tmp $<
+	tar -O -xf .bigsur-package-tmp/com_apple_MobileAsset_MacSoftwareUpdate/*.zip AssetData/Restore/BaseSystem.dmg > BaseSystem.dmg
+	hdiutil detach -force .bigsur-package-tmp
+	rm -rf .bigsur-package-tmp
+else
+BaseSystem.dmg : SharedSupport.dmg $(DARLING)
+	umount .bigsur-package-tmp || true
+	rm -rf .bigsur-package-tmp
+	mkdir .bigsur-package-tmp
+	$(DARLING) $< .bigsur-package-tmp
+	unzip -p ".bigsur-package-tmp/com_apple_MobileAsset_MacSoftwareUpdate/*.zip" AssetData/Restore/BaseSystem.dmg > BaseSystem.dmg
+	umount .bigsur-package-tmp
+	rm -rf .bigsur-package-tmp
+endif
+
+SharedSupport.dmg : InstallAssistant.pkg $(XAR)
+	$(XAR) -xf $< $@
+	touch $@
+
+InstallAssistant.pkg :
+	../../fetch-macOS.py --version 11.0.1
+
+xar/xar/src/xar : xar/
+	cd xar/xar && ./autogen.sh
+	cd xar/xar && make
+
+xar/ :
+	git clone https://github.com/VantaInc/xar.git
+
+darling-dmg/darling-dmg : darling-dmg/
+	cd darling-dmg && cmake .
+	cd darling-dmg && make
+
+darling-dmg/ :
+	git clone https://github.com/darlinghq/darling-dmg.git

--- a/scripts/create_dmg_bigsur.sh
+++ b/scripts/create_dmg_bigsur.sh
@@ -1,38 +1,3 @@
 #!/usr/bin/env bash
 
-# Create a DMG from the Big Sur Beta 3 installer app
-
-# Bail at first DMG creation error
-set -e
-
-display_help() {
-    echo "Usage: $(basename $0) [-h] [<path/to/install_app.app> <path/to/output_dmg_file.dmg>]"
-    exit 0
-}
-
-if [ "$1" == "-h" ] ; then
-    display_help
-fi
-
-if [ "$#" -eq 2 ]
-then
-    in_path=$1
-    dmg_path=$2
-elif [ "$#" -eq 0 ]
-then
-    in_path=/Applications/Install\ macOS\ Big\ Sur\ Beta.app
-    dmg_path=~/Desktop/BigSurBeta.dmg
-    echo "Using default paths:"
-    echo "Install app: $in_path"
-    echo "Output disk: $dmg_path"
-else
-    display_help
-fi
-
-hdiutil create -o "$dmg_path" -size 14g -layout GPTSPUD -fs HFS+J
-hdiutil attach "$dmg_path" -noverify -mountpoint /Volumes/install_build
-sudo "$in_path/Contents/Resources/createinstallmedia" --volume /Volumes/install_build --nointeraction
-
-# createinstallmedia  leaves a bunch of subvolumes still mounted when it exits, so we need to use -force here.
-# This might be fixed in a later Beta release:
-hdiutil detach -force "/Volumes/Install macOS Big Sur Beta"
+cd bigsur && make


### PR DESCRIPTION
Opencore  has an built in script to download the recovery inside /OpenCore-x.x.x-RELEASE /Utilities/macrecovery/
BigSur BaseSystem.dmg is only 2.8GB so makes the download much faster and less stuff to extract, also opencore can boot the BaseSystem.dmg directly on bare metal by creating a folder named ``com.apple.recovery.boot`` and dropping in  the` BaseSystem.dmg` plus the `BaseSystem.chunklist` inside of it on a formated FAT32 drive so It may be possible to boot with KVm as well I belive.
https://github.com/Broly1/OpenCore-Install-Guide/blob/master/installer-guide/linux-install.md