### PR TITLE
Big Sur image building script update

### DIFF
--- a/fetch-macOS-v2.py
+++ b/fetch-macOS-v2.py
@@ -415,49 +415,47 @@ class gdata:
 
 
 def main():
-    debug = False
-    if debug:
-        parser = argparse.ArgumentParser(description='Gather recovery information for Macs')
-        parser.add_argument('action', choices=['download', 'selfcheck', 'verify', 'guess'],
-                            help='Action to perform: "download" - performs recovery downloading,'
-                                 ' "selfcheck" checks whether MLB serial validation is possible, "verify" performs'
-                                 ' MLB serial verification, "guess" tries to find suitable mac model for MLB.')
-        parser.add_argument('-o', '--outdir', type=str, default=os.getcwd(),
-                            help='customise output directory for downloading, defaults to current directory')
-        parser.add_argument('-n', '--basename', type=str, default='',
-                            help='customise base name for downloading, defaults to remote name')
-        parser.add_argument('-b', '--board-id', type=str, default=RECENT_MAC,
-                            help='use specified board identifier for downloading, defaults to ' + RECENT_MAC)
-        parser.add_argument('-m', '--mlb', type=str, default=MLB_ZERO,
-                            help='use specified logic board serial for downloading, defaults to ' + MLB_ZERO)
-        parser.add_argument('-e', '--code', type=str, default='',
-                            help='generate product logic board serial with specified product EEEE code')
-        parser.add_argument('-os', '--os-type', type=str, default='default', choices=['default', 'latest'],
-                            help='use specified os type, defaults to default ' + MLB_ZERO)
-        parser.add_argument('-diag', '--diagnostics', action='store_true', help='download diagnostics image')
-        parser.add_argument('-v', '--verbose', action='store_true', help='print debug information')
-        parser.add_argument('-db', '--board-db', type=str, default=os.path.join(SELF_DIR, 'boards.json'),
-                            help='use custom board list for checking, defaults to boards.json')
+    parser = argparse.ArgumentParser(description='Gather recovery information for Macs')
+    parser.add_argument('--action', choices=['download', 'selfcheck', 'verify', 'guess'], default='',
+                        help='Action to perform: "download" - performs recovery downloading,'
+                             ' "selfcheck" checks whether MLB serial validation is possible, "verify" performs'
+                             ' MLB serial verification, "guess" tries to find suitable mac model for MLB.')
+    parser.add_argument('-o', '--outdir', type=str, default=os.getcwd(),
+                        help='customise output directory for downloading, defaults to current directory')
+    parser.add_argument('-n', '--basename', type=str, default='',
+                        help='customise base name for downloading, defaults to remote name')
+    parser.add_argument('-b', '--board-id', type=str, default=RECENT_MAC,
+                        help='use specified board identifier for downloading, defaults to ' + RECENT_MAC)
+    parser.add_argument('-m', '--mlb', type=str, default=MLB_ZERO,
+                        help='use specified logic board serial for downloading, defaults to ' + MLB_ZERO)
+    parser.add_argument('-e', '--code', type=str, default='',
+                        help='generate product logic board serial with specified product EEEE code')
+    parser.add_argument('-os', '--os-type', type=str, default='default', choices=['default', 'latest'],
+                        help='use specified os type, defaults to default ' + MLB_ZERO)
+    parser.add_argument('-diag', '--diagnostics', action='store_true', help='download diagnostics image')
+    parser.add_argument('-v', '--verbose', action='store_true', help='print debug information')
+    parser.add_argument('-db', '--board-db', type=str, default=os.path.join(SELF_DIR, 'boards.json'),
+                        help='use custom board list for checking, defaults to boards.json')
 
-        args = parser.parse_args()
+    args = parser.parse_args()
 
-        if args.code != '':
-            args.mlb = mlb_from_eeee(args.code)
+    if args.code != '':
+        args.mlb = mlb_from_eeee(args.code)
 
-        if len(args.mlb) != 17:
-            print('ERROR: Cannot use MLBs in non 17 character format!')
-            sys.exit(1)
+    if len(args.mlb) != 17:
+        print('ERROR: Cannot use MLBs in non 17 character format!')
+        sys.exit(1)
 
-        if args.action == 'download':
-            return action_download(args)
-        if args.action == 'selfcheck':
-            return action_selfcheck(args)
-        if args.action == 'verify':
-            return action_verify(args)
-        if args.action == 'guess':
-            return action_guess(args)
-        assert False
+    if args.action == 'download':
+        return action_download(args)
+    if args.action == 'selfcheck':
+        return action_selfcheck(args)
+    if args.action == 'verify':
+        return action_verify(args)
+    if args.action == 'guess':
+        return action_guess(args)
 
+    # No action specified, so present a download menu instead
     products = [
             {"name": "High Sierra (10.13)", "b": "Mac-7BA5B2D9E42DDD94", "m": "00000000000J80300"},
             {"name": "Mojave (10.14)", "b": "Mac-7BA5B2DFE22DDD8C", "m": "00000000000KXPG00"},

--- a/fetch-macOS.py
+++ b/fetch-macOS.py
@@ -336,15 +336,16 @@ def find_installer_app(mountpoint):
     return None
 
 
-def determine_version(version, product_info):
+def determine_version(version, title, product_info):
     if version:
         if version == 'latest':
             from distutils.version import StrictVersion
             latest_version = StrictVersion('0.0.0')
             for index, product_id in enumerate(product_info):
-                d = product_info[product_id]['version']
-                if d > latest_version:
-                    latest_version = d
+                if not title or product_info[product_id]['title'] == title:
+                    d = product_info[product_id]['version']
+                    if d > latest_version:
+                        latest_version = d
 
             if latest_version == StrictVersion("0.0.0"):
                 print("Could not find latest version {}")
@@ -408,6 +409,11 @@ def main():
                         help='The version to download in the format of '
                              '"$major.$minor.$patch", e.g. "10.15.4". Can '
                              'be "latest" to download the latest version.')
+    parser.add_argument('--title', metavar='title',
+                        default=None,
+                        help='When using "--version latest", you can use '
+                             'this to filter the search to only products with '
+                             'this title')
     parser.add_argument('--compress', action='store_true',
                         help='Output a read-only compressed disk image with '
                              'the Install macOS app at the root. This is now the '
@@ -436,7 +442,7 @@ def main():
         print('No macOS installer products found in the sucatalog.', file=sys.stderr)
         exit(-1)
 
-    product_id, product_title = determine_version(args.version, product_info)
+    product_id, product_title = determine_version(args.version, args.title, product_info)
     print(product_id, product_title)
 
     # download all the packages for the selected product

--- a/scripts/bigsur/Makefile
+++ b/scripts/bigsur/Makefile
@@ -1,0 +1,108 @@
+# Builds either a recovery image (BigSur-recovery.img) or a full installer (BigSur-full.img) for Big Sur.
+
+# To build the full installer you must run this on macOS. 
+# The recovery can be built on either macOS or Linux.
+
+# For Ubuntu (or similar Linux distribution) you'll need to run this first to get the required packages:
+# sudo apt install g++ git qemu-utils libxml2-dev libssl-dev zlib1g-dev cmake libbz2-dev libfuse-dev fuse autoconf unzip
+
+# For macOS you'll probably need to run xcode-select --install to get the commandline tools
+
+BIG_SUR_APP=/Applications/Install\ macOS\ Big\ Sur.app
+
+LINUX_TOOLS = qemu-img git cmake autoconf
+
+OS := 
+UNAME_S := $(shell uname -s)
+
+ifeq ($(UNAME_S),Darwin)
+	OS = MACOS
+endif
+
+# Use systemwide xar/darling-img if available:
+XAR := $(shell which xar)
+DARLING := $(shell which darling-dmg)
+
+# Otherwise we'll build them from source:
+ifeq ($(XAR),)
+XAR = xar/xar/src/xar
+endif
+
+ifeq ($(DARLING),)
+DARLING = darling-dmg/darling-dmg
+endif
+
+# If this is Linux make sure we have all our build tools available:
+ifeq ($(OS),)
+	K := $(foreach exec,$(LINUX_TOOLS),\
+			$(if $(shell which $(exec)),some string,$(error "Missing required $(exec) tool for build")))
+endif
+
+all: BigSur-recovery.img
+
+BigSur-full.img : BigSur-full.dmg
+	mv $< $@ 
+
+ifeq ($(OS),MACOS)
+BigSur-full.dmg : $(BIG_SUR_APP)
+	hdiutil create -o "$@" -size 14g -layout GPTSPUD -fs HFS+J
+	hdiutil attach -noverify -mountpoint /Volumes/install_build "$@"
+	sudo "$</Contents/Resources/createinstallmedia" --volume /Volumes/install_build --nointeraction
+	
+	# createinstallmedia leaves a bunch of subvolumes still mounted when it exits, so we need to use -force here.
+	hdiutil detach -force "/Volumes/Install macOS Big Sur"
+else
+BigSur-full.dmg :
+	$(error "Building a full installer requires this script to be run on macOS, build BigSur-recovery.img instead")
+endif
+
+$(BIG_SUR_APP) : InstallAssistant.pkg
+	sudo installer -pkg $< -target /
+
+BigSur-recovery.img : BaseSystem.dmg
+ifeq ($(OS),MACOS)
+	hdiutil convert $< -format UDRW -o $@
+else
+	qemu-img convert $< -O raw $@
+endif
+
+ifeq ($(OS),MACOS)
+BaseSystem.dmg : SharedSupport.dmg
+	hdiutil detach -force .bigsur-package-tmp || true
+	rm -rf .bigsur-package-tmp
+	mkdir .bigsur-package-tmp
+	hdiutil attach -quiet -nobrowse -mountpoint .bigsur-package-tmp $<
+	tar -O -xf .bigsur-package-tmp/com_apple_MobileAsset_MacSoftwareUpdate/*.zip AssetData/Restore/BaseSystem.dmg > BaseSystem.dmg
+	hdiutil detach -force .bigsur-package-tmp
+	rm -rf .bigsur-package-tmp
+else
+BaseSystem.dmg : SharedSupport.dmg $(DARLING)
+	umount .bigsur-package-tmp || true
+	rm -rf .bigsur-package-tmp
+	mkdir .bigsur-package-tmp
+	$(DARLING) $< .bigsur-package-tmp
+	unzip -p ".bigsur-package-tmp/com_apple_MobileAsset_MacSoftwareUpdate/*.zip" AssetData/Restore/BaseSystem.dmg > BaseSystem.dmg
+	umount .bigsur-package-tmp
+	rm -rf .bigsur-package-tmp
+endif
+
+SharedSupport.dmg : InstallAssistant.pkg $(XAR)
+	$(XAR) -xf $< $@
+	touch $@
+
+InstallAssistant.pkg :
+	../../fetch-macOS.py --version 11.2.1
+
+xar/xar/src/xar : xar/
+	cd xar/xar && ./autogen.sh
+	cd xar/xar && make
+
+xar/ :
+	git clone https://github.com/VantaInc/xar.git
+
+darling-dmg/darling-dmg : darling-dmg/
+	cd darling-dmg && cmake .
+	cd darling-dmg && make
+
+darling-dmg/ :
+	git clone https://github.com/darlinghq/darling-dmg.git

--- a/scripts/bigsur/Makefile
+++ b/scripts/bigsur/Makefile
@@ -4,32 +4,19 @@
 # The recovery can be built on either macOS or Linux.
 
 # For Ubuntu (or similar Linux distribution) you'll need to run this first to get the required packages:
-# sudo apt install g++ git qemu-utils libxml2-dev libssl-dev zlib1g-dev cmake libbz2-dev libfuse-dev fuse autoconf unzip
+# sudo apt install qemu-utils make
 
 # For macOS you'll probably need to run xcode-select --install to get the commandline tools
 
 BIG_SUR_APP=/Applications/Install\ macOS\ Big\ Sur.app
 
-LINUX_TOOLS = qemu-img git cmake autoconf
+LINUX_TOOLS = qemu-img
 
 OS := 
 UNAME_S := $(shell uname -s)
 
 ifeq ($(UNAME_S),Darwin)
 	OS = MACOS
-endif
-
-# Use systemwide xar/darling-img if available:
-XAR := $(shell which xar)
-DARLING := $(shell which darling-dmg)
-
-# Otherwise we'll build them from source:
-ifeq ($(XAR),)
-XAR = xar/xar/src/xar
-endif
-
-ifeq ($(DARLING),)
-DARLING = darling-dmg/darling-dmg
 endif
 
 # If this is Linux make sure we have all our build tools available:
@@ -40,8 +27,8 @@ endif
 
 all: BigSur-recovery.img
 
-BigSur-full.img : BigSur-full.dmg
-	mv $< $@ 
+%.img : %.dmg
+	ln $< $@
 
 ifeq ($(OS),MACOS)
 BigSur-full.dmg : $(BIG_SUR_APP)
@@ -53,56 +40,26 @@ BigSur-full.dmg : $(BIG_SUR_APP)
 	hdiutil detach -force "/Volumes/Install macOS Big Sur"
 else
 BigSur-full.dmg :
-	$(error "Building a full installer requires this script to be run on macOS, build BigSur-recovery.img instead")
+	$(error "Building a full installer requires this script to be run on macOS, run 'make BigSur-recovery.img' instead")
 endif
 
 $(BIG_SUR_APP) : InstallAssistant.pkg
 	sudo installer -pkg $< -target /
 
-BigSur-recovery.img : BaseSystem.dmg
+BigSur-recovery.dmg : BaseSystem.dmg
+	rm -f $@
 ifeq ($(OS),MACOS)
 	hdiutil convert $< -format UDRW -o $@
 else
 	qemu-img convert $< -O raw $@
 endif
 
-ifeq ($(OS),MACOS)
-BaseSystem.dmg : SharedSupport.dmg
-	hdiutil detach -force .bigsur-package-tmp || true
-	rm -rf .bigsur-package-tmp
-	mkdir .bigsur-package-tmp
-	hdiutil attach -quiet -nobrowse -mountpoint .bigsur-package-tmp $<
-	tar -O -xf .bigsur-package-tmp/com_apple_MobileAsset_MacSoftwareUpdate/*.zip AssetData/Restore/BaseSystem.dmg > BaseSystem.dmg
-	hdiutil detach -force .bigsur-package-tmp
-	rm -rf .bigsur-package-tmp
-else
-BaseSystem.dmg : SharedSupport.dmg $(DARLING)
-	umount .bigsur-package-tmp || true
-	rm -rf .bigsur-package-tmp
-	mkdir .bigsur-package-tmp
-	$(DARLING) $< .bigsur-package-tmp
-	unzip -p ".bigsur-package-tmp/com_apple_MobileAsset_MacSoftwareUpdate/*.zip" AssetData/Restore/BaseSystem.dmg > BaseSystem.dmg
-	umount .bigsur-package-tmp
-	rm -rf .bigsur-package-tmp
-endif
-
-SharedSupport.dmg : InstallAssistant.pkg $(XAR)
-	$(XAR) -xf $< $@
-	touch $@
+BaseSystem.dmg :
+	../../fetch-macOS-v2.py --action download --board-id Mac-E43C1C25D4880AD6
 
 InstallAssistant.pkg :
-	../../fetch-macOS.py --version 11.2.1
+	../../fetch-macOS.py --version latest --title "macOS Big Sur"
 
-xar/xar/src/xar : xar/
-	cd xar/xar && ./autogen.sh
-	cd xar/xar && make
-
-xar/ :
-	git clone https://github.com/VantaInc/xar.git
-
-darling-dmg/darling-dmg : darling-dmg/
-	cd darling-dmg && cmake .
-	cd darling-dmg && make
-
-darling-dmg/ :
-	git clone https://github.com/darlinghq/darling-dmg.git
+clean :
+	rm -f BaseSystem.chunklist BaseSystem.dmg SharedSupport.dmg InstallAssistant.pkg BigSur-recovery.img BigSur-full.img
+	rm -rf content


### PR DESCRIPTION
This new makefile takes advantage of fetch-macOS-v2 to simplify the build dependencies for building the recovery image. 

I added some features to the fetch macOS scripts so that the Makefile can automatically fetch the newest Big Sur version as new point releases are added by Apple.