### PR TITLE
Picker to choose default if no keypress within 15 seconds

### DIFF
--- a/OpenCore-Catalina/config.plist
+++ b/OpenCore-Catalina/config.plist
@@ -563,7 +563,7 @@
 			<key>TakeoffDelay</key>
 			<integer>0</integer>
 			<key>Timeout</key>
-			<integer>0</integer>
+			<integer>15</integer>
 		</dict>
 		<key>Debug</key>
 		<dict>


### PR DESCRIPTION
Add 15 second timeout to the Picker config.plist, so the machine will boot the default option if no key is pressed.