### PR TITLE
Add installer build script for macOS 12 Monterery Developer Beta

### DIFF
--- a/scripts/bigsur/Makefile
+++ b/scripts/bigsur/Makefile
@@ -28,7 +28,7 @@ endif
 all: BigSur-recovery.img
 
 %.img : %.dmg
-	ln $< $@
+	ln $< $@ || cp $< $@ 
 
 ifeq ($(OS),MACOS)
 BigSur-full.dmg : $(BIG_SUR_APP)
@@ -58,7 +58,7 @@ BaseSystem.dmg :
 	../../fetch-macOS-v2.py --action download --board-id Mac-E43C1C25D4880AD6
 
 InstallAssistant.pkg :
-	../../fetch-macOS.py --version latest --title "macOS Big Sur"
+	../../backups/fetch-macOS.py --version latest --title "macOS Big Sur"
 
 clean :
 	rm -f BaseSystem.chunklist BaseSystem.dmg SharedSupport.dmg InstallAssistant.pkg BigSur-recovery.img BigSur-full.img

--- a/scripts/monterey/Makefile
+++ b/scripts/monterey/Makefile
@@ -1,0 +1,19 @@
+# Builds a full installer (Monterey-full.img) for Monterey Developer Beta.
+
+# You need to opt-in to the Developer beta program first and get the Monterey installer app using System Update 
+
+MONTEREY_APP=/Applications/Install\ macOS\ 12\ Beta.app
+
+all: Monterey-full.img
+
+%.img : %.dmg
+	ln $< $@
+
+Monterey-full.dmg : $(MONTEREY_APP)
+	hdiutil create -o "$@" -size 14g -layout GPTSPUD -fs HFS+J
+	hdiutil attach -noverify -mountpoint /Volumes/install_build "$@"
+	sudo "$</Contents/Resources/createinstallmedia" --volume /Volumes/install_build --nointeraction
+	hdiutil detach "/Volumes/Install macOS 12 Beta"
+
+clean :
+	rm -f Monterey-recovery.img Monterey-full.img

--- a/scripts/monterey/Makefile
+++ b/scripts/monterey/Makefile
@@ -7,7 +7,7 @@ MONTEREY_APP=/Applications/Install\ macOS\ 12\ Beta.app
 all: Monterey-full.img
 
 %.img : %.dmg
-	ln $< $@
+	ln $< $@ || cp $< $@ 
 
 Monterey-full.dmg : $(MONTEREY_APP)
 	hdiutil create -o "$@" -size 14g -layout GPTSPUD -fs HFS+J


### PR DESCRIPTION
This builds an installer on macOS using the "Install macOS 12 Beta" app (which is available from the Apple Developer Beta Program).

To boot Monterey, config.plist needs a max version bump for my Penryn cpuid patch, like so:

https://github.com/thenickdude/KVM-Opencore/commit/9ca9f357fbcfaca468124af9dd30032680ede609

I've removed the algrey CPU topology patch in favour of OpenCore 0.7.0's new "ProvideCurrentCpuInfo" quirk, which needs to be enabled:

https://github.com/thenickdude/KVM-Opencore/commit/1241cfd4e8811491d379dda6bef6e5d19c9306f8

**Note:** After Monterey installation, when you initially get to the desktop, if you shutdown or reboot from this point macOS will get stuck in an infinite loop during boot. This is because the loginwindow process currently crashes when it is displayed. To avoid showing the loginwindow, before you reboot, either turn on FileVault encryption in Security settings, or enable automatic login for your account in the Users & Groups settings.