### PR TITLE
 Add links to usbfluxd & Iphone_docker_osx_passthrough

### DIFF
--- a/notes.md
+++ b/notes.md
@@ -264,9 +264,17 @@ $ make -j8; make install
 
 ### Connect iPhone / iPad to macOS guest
 
-Please passthrough a PCIe USB card to the virtual machine to be able to connect
-iDevices (iPhone / iPad) to it.
+iDevices can be passed through in two ways: USB or USB OTA.
 
+USB OTA:
+
+https://github.com/corellium/usbfluxd
+
+https://github.com/EthanArbuckle/usbfluxd-usage
+
+VFIO USB Passthrough:
+
+https://github.com/Silfalion/Iphone_docker_osx_passthrough
 
 ### Exposing AES-NI instructions to macOS
 


### PR DESCRIPTION
Added light instructions for VFIO and USB OTA links to notes page.

More instructions here, let me know if you want me to add them for OSX-KVM specific :)

https://github.com/sickcodes/docker-osx#usbfluxd-iphone-usb---network-style-passthrough-osx-kvm-docker-osx