### PR TITLE
Avoid deprecated egrep(1)

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -118,4 +118,6 @@
 
 - deftdawg - Various correctness and robustness fixes - thanks!
 
+- sickcodes - Keep being awesome ;)
+
 Note: Individual files have more specific 'credits' in them.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ help (pull-requests!) with the following work items:
 
 * QEMU >= 4.2.0
 
-* A CPU with Intel VT-x / AMD SVM support is required (`egrep '(vmx|svm)' /proc/cpuinfo`)
+* A CPU with Intel VT-x / AMD SVM support is required (`grep -e vmx -e svm /proc/cpuinfo`)
 
 * A CPU with SSE4.1 support is required for >= macOS Sierra
 

--- a/notes.md
+++ b/notes.md
@@ -264,8 +264,17 @@ $ make -j8; make install
 
 ### Connect iPhone / iPad to macOS guest
 
-Please passthrough a PCIe USB card to the virtual machine to be able to connect
-iDevices (iPhone / iPad) to it.
+iDevices can be passed through in two ways: USB or USB OTA.
+
+USB OTA:
+
+https://github.com/corellium/usbfluxd
+
+https://github.com/EthanArbuckle/usbfluxd-usage
+
+VFIO USB Passthrough:
+
+https://github.com/Silfalion/Iphone_docker_osx_passthrough
 
 
 ### Exposing AES-NI instructions to macOS


### PR DESCRIPTION
Instead of using egrep(1), which is deprecated, use grep(1) with the
'-e' option specified twice.