### PR TITLE
Improve Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,15 @@
+DISK_SIZE := 128G
+
+all: BaseSystem.img mac_hdd_ng.img
+
+BaseSystem.img: BaseSystem.dmg
+	qemu-img convert BaseSystem.dmg -O raw BaseSystem.img
+
+BaseSystem.dmg:
+	./fetch-macOS-v2.py
+
+mac_hdd_ng.img:
+	qemu-img create -f qcow2 mac_hdd_ng.img ${DISK_SIZE}
+
 clean:
-	rm -rf content || true
+	rm -rf BaseSystem{.dmg,.img,.chunklist} mac_hdd_ng.img


### PR DESCRIPTION
This will make all the steps for downloading the macOS image and generating the virtual HDD easier, by just running one command (`make`).