### PR TITLE
Make default disk size bigger (micro edit)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # export SHORTNAME=monterey
-DISK_SIZE := 128G
+DISK_SIZE := 256G
 
 all: BaseSystem.img mac_hdd_ng.img
 


### PR DESCRIPTION
128gb is a bit low and very hard to grow APFS inside a qcow after creation (convert to raw 128GB, grow disk, expand partition in apple recovery, etc. convert back)