### PR TITLE
Update board ID to avoid fetching Ventura for Monterey recovery

### DIFF
--- a/scripts/monterey/Makefile
+++ b/scripts/monterey/Makefile
@@ -60,7 +60,7 @@ else
 endif
 
 BaseSystem.dmg :
-	../../fetch-macOS-v2.py --action download --board-id Mac-7BA5B2D9E42DDD94 --os latest
+	../../fetch-macOS-v2.py --action download --board-id Mac-F60DEB81FF30ACF6 --os latest
 
 InstallAssistant.pkg :
 	../../backups/fetch-macOS.py --version latest --title "macOS Monterey"


### PR DESCRIPTION
Updates the board ID for Monterey to a version that will not be getting support for Ventura (Mac Pro 2013), so that when Ventura goes gold it doesn't accidentally download that instead of Monterey.