### PR TITLE
[UPD] .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 *.iso
-mac_hdd.img
-mac_hdd_ng.img
+*.chunklist
 *.sha256sum
 *.sucatalog
 *.img
@@ -8,6 +7,4 @@ mac_hdd_ng.img
 *.dist
 *.smd
 *.dmg
-OVMF_VARS-1024x768.fd
-OVMF_VARS*.fd
 OpenCore-Catalina/EFI/OC/Resources/

--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@
 *.dist
 *.smd
 *.dmg
+*.swp
 OpenCore-Catalina/EFI/OC/Resources/

--- a/OpenCore-Boot.sh
+++ b/OpenCore-Boot.sh
@@ -13,6 +13,10 @@
 # NOTE: Tweak the "MY_OPTIONS" line in case you are having booting problems!
 ############################################################################
 
+# Tell git to ignore changes in files that will change anyway after first run
+# https://compiledsuccessfully.dev/git-skip-worktree/
+git update-index --skip-worktree OVMF_VARS*.fd
+
 MY_OPTIONS="+ssse3,+sse4.2,+popcnt,+avx,+aes,+xsave,+xsaveopt,check"
 
 # This script works for Big Sur, Catalina, Mojave, and High Sierra. Tested with


### PR DESCRIPTION
Cleans up .gitignore and uses git's "skip-worktree" functionality to ignore changes in the binary blobs after cloning.