### PR TITLE
[UPD] switch bootindex so that mac comes first

### DIFF
--- a/OpenCore-Boot.sh
+++ b/OpenCore-Boot.sh
@@ -46,11 +46,11 @@ args=(
   -device ich9-intel-hda -device hda-duplex
   -device ich9-ahci,id=sata
   -drive id=OpenCoreBoot,if=none,snapshot=on,format=qcow2,file="$REPO_PATH/OpenCore/OpenCore.qcow2"
-  -device ide-hd,bus=sata.2,drive=OpenCoreBoot
-  -device ide-hd,bus=sata.3,drive=InstallMedia
+  -device ide-hd,bus=sata.2,bootindex=3,drive=OpenCoreBoot
+  -device ide-hd,bus=sata.3,bootindex=2,drive=InstallMedia
   -drive id=InstallMedia,if=none,file="$REPO_PATH/BaseSystem.img",format=raw
   -drive id=MacHDD,if=none,file="$REPO_PATH/mac_hdd_ng.img",format=qcow2
-  -device ide-hd,bus=sata.4,drive=MacHDD
+  -device ide-hd,bus=sata.4,bootindex=1,drive=MacHDD
   # -netdev tap,id=net0,ifname=tap0,script=no,downscript=no -device virtio-net-pci,netdev=net0,id=net0,mac=52:54:00:c9:18:27
   -netdev user,id=net0 -device virtio-net-pci,netdev=net0,id=net0,mac=52:54:00:c9:18:27
   # -netdev user,id=net0 -device vmxnet3,netdev=net0,id=net0,mac=52:54:00:c9:18:27  # Note: Use this line for High Sierra


### PR DESCRIPTION
I haven't tested if this does not mess up installation, but after installation this is useful to me because otherwise it waits for input in headless mode