### PR TITLE
Severe improvements for OpenCore-Boot

### DIFF
--- a/OpenCore-Boot-CD.sh
+++ b/OpenCore-Boot-CD.sh
@@ -50,6 +50,8 @@ args=(
   -device ide-hd,bus=sata.4,drive=MacHDD
   # -netdev tap,id=net0,ifname=tap0,script=no,downscript=no -device vmxnet3,netdev=net0,id=net0,mac=52:54:00:c9:18:27
   -netdev user,id=net0 -device vmxnet3,netdev=net0,id=net0,mac=52:54:00:c9:18:27
+  -accel kvm
+  -display gtk 
   -monitor stdio
   -device VGA,vgamem_mb=128
 )


### PR DESCRIPTION
The two added lines improved my Hackintosh significently, like to the point where it doesn't feel all that non-native. The first one explicitly adds kvm as the acceleration to be used (idk if it truly does that much on it's own) and the second one is using the display gtk instead of sdl, which lessens cpu strain immensely 