### PR TITLE
Ventura requires avx2 to be enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ Phenom II X3 720 does not. Ryzen processors work just fine.
   ```
 
   Note: This same script works for Big Sur, Catalina, Mojave, and High Sierra.
+  Ventura requires avx2 cpu instruction to be enabled by changing `-cpu Penryn` to `-cpu host` and adding `+avx2` to the `MY_OPTIONS` 
+  line in `OpenCore-Boot.sh` see [notes](https://github.com/kholia/OSX-KVM/blob/master/notes.md#exposing-avx-and-avx2-instructions-to-macos).
 
 - Use the `Disk Utility` tool within the macOS installer to partition, and
   format the virtual disk attached to the macOS VM.


### PR DESCRIPTION
Hi, thank you the commitment maintaining this great project. I would like to make small changes to prevent others from having the same situation that I've had trying to install macOS Ventura. I'm unable to boot after normal installation following the `README.md` guide with errors relating to no dyld cache or library not found (e.g. libSystem.B.dylib): 

![Screenshot from 2022-10-28 06-03-20](https://user-images.githubusercontent.com/66469454/198676540-9e49aa66-c090-4fa0-a618-8a63a4186db9.png)

It seems to be the problem of Apple dropping pre-Haswell support in macOS, that moves dyld to Preboot images OS.img according to [this](https://khronokernel.github.io/macos/2022/06/22/VENTURA-DYLD.html), and [this](https://github.com/dortania/OpenCore-Legacy-Patcher/issues/998). The dyld cache is only available for CPU with the avx2 instruction. An easy fix for this is to change `-cpu Penryn` to `-cpu host` and adding `+avx2` to the `MY_OPTIONS` line in `OpenCore-Boot.sh` (if the host CPU supports it).

This PR only adds a note to the README file, should OpenCore-Boot script be modified?