### PR TITLE
feat(ventura): offline installer creation script

### DIFF
--- a/scripts/create_dmg_monterey.sh
+++ b/scripts/create_dmg_monterey.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Create a "ISO" (DMG) image for powering offline macOS installations
+
+# Bail at first ISO creation error
+set -e
+
+display_help() {
+    echo "Usage: $(basename $0) [-h] [<path/to/install_app.app> <path/to/output_iso_file.iso>]"
+    exit 0
+}
+
+if [ "$1" == "-h" ] ; then
+    display_help
+fi
+
+if [ "$#" -eq 2 ]
+then
+    in_path=$1
+    dmg_path=$2
+elif [ "$#" -eq 0 ]
+then
+    in_path=/Applications/Install\ macOS\ Monterey.app
+    dmg_path=~/Desktop/Monterey.dmg
+    echo "Using default paths:"
+    echo "Install app: $in_path"
+    echo "Output disk: $dmg_path"
+else
+    display_help
+fi
+
+# Borrrowed from multiple internet sources
+hdiutil create -o "$dmg_path" -size 15g -layout GPTSPUD -fs HFS+J
+hdiutil attach "$dmg_path" -noverify -mountpoint /Volumes/install_build
+sudo "$in_path/Contents/Resources/createinstallmedia" --volume /Volumes/install_build --nointeraction
+
+# createinstallmedia may leave a bunch of subvolumes still mounted when it exits, so we need to use -force here.
+hdiutil detach -force "/Volumes/Install macOS Monterey"

--- a/scripts/create_dmg_ventura.sh
+++ b/scripts/create_dmg_ventura.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Create a "ISO" (DMG) image for powering offline macOS installations
+
+# Bail at first ISO creation error
+set -e
+
+display_help() {
+    echo "Usage: $(basename $0) [-h] [<path/to/install_app.app> <path/to/output_iso_file.iso>]"
+    exit 0
+}
+
+if [ "$1" == "-h" ] ; then
+    display_help
+fi
+
+if [ "$#" -eq 2 ]
+then
+    in_path=$1
+    dmg_path=$2
+elif [ "$#" -eq 0 ]
+then
+    in_path=/Applications/Install\ macOS\ Ventura.app
+    dmg_path=~/Desktop/Ventura.dmg
+    echo "Using default paths:"
+    echo "Install app: $in_path"
+    echo "Output disk: $dmg_path"
+else
+    display_help
+fi
+
+# Borrrowed from multiple internet sources
+hdiutil create -o "$dmg_path" -size 15g -layout GPTSPUD -fs HFS+J
+hdiutil attach "$dmg_path" -noverify -mountpoint /Volumes/install_build
+sudo "$in_path/Contents/Resources/createinstallmedia" --volume /Volumes/install_build --nointeraction
+
+# createinstallmedia may leave a bunch of subvolumes still mounted when it exits, so we need to use -force here.
+hdiutil detach -force "/Volumes/Install macOS Ventura"


### PR DESCRIPTION
Script creation process: 

0- download full installer (I used this link: https://mrmacintosh.com/macos-ventura-13-full-installer-database-download-directly-from-apple/ to get the link)
1- clone mojave script to ventura, changing names as appropriate, attempt to run it
2- witness error message indicating 7.1g more space is needed, round up and change 7g image to 15g image, run it again

All the scripts are quite similar and catalina was not much different then mojave so the script base for step 1 should be fine

Ventura.dmg is on the desktop, so this appears to work

Cheers!