### PR TITLE
Add NixOS flake support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,56 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1669833724,
+        "narHash": "sha256-/HEZNyGbnQecrgJnfE8d0WC5c1xuPSD2LUpB6YXlg4c=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4d2b37a84fad1091b9de401eb450aae66f1a741e",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "22.11",
+        "type": "indirect"
+      }
+    },
+    "osx-kvm": {
+      "flake": false,
+      "locked": {
+        "lastModified": 0,
+        "narHash": "sha256-d4JZtpX3YhxsCIkAPcAyfzew18Su90AsP5BeNUqxUD0=",
+        "path": "./",
+        "type": "path"
+      },
+      "original": {
+        "path": "./",
+        "type": "path"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "osx-kvm": "osx-kvm"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,34 @@
+{
+  description = "OSX-KVM allows to run macOS on Linux machines";
+
+  inputs.nixpkgs.url = "nixpkgs/22.11";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+  inputs.osx-kvm.url = "path:./";
+  inputs.osx-kvm.flake = false;
+
+  outputs = { self, nixpkgs, flake-utils, osx-kvm }:
+
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+
+        start =
+          pkgs.writeShellScriptBin "start" ''
+            set -e
+            if [ ! -e BaseSystem.dmg ];then
+              ${pkgs.python3}/bin/python ${osx-kvm}/fetch-macOS-v2.py
+            fi
+            if [ ! -e BaseSystem.img ];then
+              ${pkgs.qemu}/bin/qemu-img convert BaseSystem.dmg -O raw BaseSystem.img
+            fi
+            if [ ! -e mac_hdd_ng.img ];then
+              ${pkgs.qemu}/bin/qemu-img create -f qcow2 mac_hdd_ng.img 128G
+            fi
+            source ${osx-kvm}/OpenCore-Boot.sh
+          '';
+      in
+      {
+        packages = { inherit start; };
+        defaultPackage = start;
+      });
+}


### PR DESCRIPTION
This PR adds NixOS flake support. With this, the tool can be easily used in NixOS by just running

```
nix run github:kholia/OSX-KVM 
```

See instructions in the NixOS wiki https://nixos.wiki/wiki/OSX-KVM