### PR TITLE
scripts/ventura/Makefile resize to 15G

### DIFF
--- a/scripts/ventura/Makefile
+++ b/scripts/ventura/Makefile
@@ -33,7 +33,7 @@ all: Ventura-recovery.img
 ifeq ($(OS),MACOS)
 
 Ventura-full.dmg : $(VENTURA_APP)
-	hdiutil create -o "$@" -size 14g -layout GPTSPUD -fs HFS+J
+	hdiutil create -o "$@" -size 15g -layout GPTSPUD -fs HFS+J
 	hdiutil attach -noverify -mountpoint /Volumes/install_build "$@"
 	sudo "$</Contents/Resources/createinstallmedia" --volume /Volumes/install_build --nointeraction
 	hdiutil detach "/Volumes/Install macOS Ventura"


### PR DESCRIPTION
sudo "/Applications/Install macOS Ventura.app/Contents/Resources/createinstallmedia" --volume /Volumes/install_build --nointeraction
/Volumes/install_build is not large enough for install media. An additional 54.5 MB is needed.
make: *** [Ventura-full.dmg] Error 246