### PR TITLE
Update makefiles for new download directory name, bump Ventura board ID

### DIFF
--- a/scripts/bigsur/Makefile
+++ b/scripts/bigsur/Makefile
@@ -46,7 +46,7 @@ endif
 $(BIG_SUR_APP) : InstallAssistant.pkg
 	sudo installer -pkg $< -target /
 
-BigSur-recovery.dmg : BaseSystem.dmg
+BigSur-recovery.dmg : com.apple.recovery.boot/BaseSystem.dmg
 	rm -f $@
 ifeq ($(OS),MACOS)
 	hdiutil convert $< -format UDRW -o $@
@@ -54,12 +54,12 @@ else
 	qemu-img convert $< -O raw $@
 endif
 
-BaseSystem.dmg :
+com.apple.recovery.boot/BaseSystem.dmg :
 	../../fetch-macOS-v2.py --action download --board-id Mac-2BD1B31983FE1663
 
 InstallAssistant.pkg :
 	../../backups/fetch-macOS.py --version latest --title "macOS Big Sur"
 
 clean :
-	rm -f BaseSystem.chunklist BaseSystem.dmg SharedSupport.dmg InstallAssistant.pkg BigSur-recovery.img BigSur-full.img
-	rm -rf content
+	rm -f SharedSupport.dmg InstallAssistant.pkg BigSur-recovery.img BigSur-full.img
+	rm -rf content com.apple.recovery.boot

--- a/scripts/monterey/Makefile
+++ b/scripts/monterey/Makefile
@@ -51,7 +51,7 @@ Monterey-full.dmg :
 
 endif
 
-Monterey-recovery.dmg : BaseSystem.dmg
+Monterey-recovery.dmg : com.apple.recovery.boot/BaseSystem.dmg
 	rm -f $@
 ifeq ($(OS),MACOS)
 	hdiutil convert $< -format UDRW -o $@
@@ -59,12 +59,12 @@ else
 	qemu-img convert $< -O raw $@
 endif
 
-BaseSystem.dmg :
+com.apple.recovery.boot/BaseSystem.dmg :
 	../../fetch-macOS-v2.py --action download --board-id Mac-F60DEB81FF30ACF6 --os latest
 
 InstallAssistant.pkg :
 	../../backups/fetch-macOS.py --version latest --title "macOS Monterey"
 
 clean :
-	rm -f BaseSystem.chunklist BaseSystem.dmg SharedSupport.dmg InstallAssistant.pkg Monterey-recovery.img Monterey-full.img
-	rm -rf content
+	rm -f SharedSupport.dmg InstallAssistant.pkg Monterey-recovery.img Monterey-full.img
+	rm -rf content com.apple.recovery.boot

--- a/scripts/ventura/Makefile
+++ b/scripts/ventura/Makefile
@@ -51,7 +51,7 @@ Ventura-full.dmg :
 
 endif
 
-Ventura-recovery.dmg : BaseSystem.dmg
+Ventura-recovery.dmg : com.apple.recovery.boot/BaseSystem.dmg
 	rm -f $@
 ifeq ($(OS),MACOS)
 	hdiutil convert $< -format UDRW -o $@
@@ -59,12 +59,12 @@ else
 	qemu-img convert $< -O raw $@
 endif
 
-BaseSystem.dmg :
-	../../fetch-macOS-v2.py --action download --board-id Mac-AF89B6D9451A490B --os latest
+com.apple.recovery.boot/BaseSystem.dmg :
+	../../fetch-macOS-v2.py --action download --board-id Mac-4B682C642B45593E --os latest
 
 InstallAssistant.pkg :
 	../../backups/fetch-macOS.py --version latest --title "macOS Ventura"
 
 clean :
-	rm -f BaseSystem.chunklist BaseSystem.dmg SharedSupport.dmg InstallAssistant.pkg Ventura-recovery.img Ventura-full.img Ventura-recovery.dmg Ventura-full.dmg
-	rm -rf content
+	rm -f SharedSupport.dmg InstallAssistant.pkg Ventura-recovery.img Ventura-full.img Ventura-recovery.dmg Ventura-full.dmg
+	rm -rf content com.apple.recovery.boot


### PR DESCRIPTION
The downloader now downloads recoveries to "com.apple.recovery.boot", this commit updates the makefiles to look for the files in that new directory instead.

Updated the Ventura board ID in the makefile too to fix it downloading Sonoma by mistake