### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ processors work just fine (even for macOS Sonoma).
 * Install QEMU and other packages.
 
   ```
-  sudo apt-get install qemu uml-utilities virt-manager git \
+  sudo apt-get install qemu-system uml-utilities virt-manager git \
       wget libguestfs-tools p7zip-full make dmg2img tesseract-ocr \
       tesseract-ocr-eng genisoimage -y
   ```


### PR DESCRIPTION
I am getting this message when installing the qemu package as given in the README. "Package qemu is not available, but is referred to by another package. This may mean that the package is missing, has been obsoleted, or is only available from another source. "

qemu package has been changed to qemu-system in the latest versions of ubuntu. 