### PR TITLE
Provide a hint for spice in qemu config

### DIFF
--- a/OpenCore-Boot.sh
+++ b/OpenCore-Boot.sh
@@ -62,6 +62,7 @@ args=(
   # -netdev user,id=net0 -device vmxnet3,netdev=net0,id=net0,mac=52:54:00:c9:18:27  # Note: Use this line for High Sierra
   -monitor stdio
   -device vmware-svga
+  # -spice port=5900,addr=127.0.0.1,disable-ticketing=on
 )
 
 qemu-system-x86_64 "${args[@]}"


### PR DESCRIPTION
In case somebody prefers connecting via spice, it can come handy. Spice is already used in other configs, so hopefully saves people a bit of googling.