### PR TITLE
cd to script location

### DIFF
--- a/OpenCore-Boot.sh
+++ b/OpenCore-Boot.sh
@@ -17,6 +17,8 @@
 #
 ###############################################################################
 
+#cd to script location
+cd "${0%/*}"
 
 MY_OPTIONS="+ssse3,+sse4.2,+popcnt,+avx,+aes,+xsave,+xsaveopt,check"
 


### PR DESCRIPTION
It's easier to quickly start the script if changes the working directory to the script's location.