### PR TITLE
Make output of fetch-macOS-v2 more clear.

### DIFF
--- a/OpenCore/config.plist
+++ b/OpenCore/config.plist
@@ -1083,7 +1083,7 @@
 			<key>PasswordSalt</key>
 			<data></data>
 			<key>ScanPolicy</key>
-			<integer>0</integer>
+			<integer>17761027</integer>
 			<key>SecureBootModel</key>
 			<string>Disabled</string>
 			<key>Vault</key>
@@ -1795,7 +1795,7 @@
 			<key>ReplaceTabWithSpace</key>
 			<false/>
 			<key>Resolution</key>
-			<string>1344x840@32</string>
+			<string>1920x1080@32</string>
 			<key>SanitiseClearScreen</key>
 			<false/>
 			<key>TextRenderer</key>

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ processors work just fine (even for macOS Sonoma).
   ```
   sudo apt-get install qemu uml-utilities virt-manager git \
       wget libguestfs-tools p7zip-full make dmg2img tesseract-ocr \
-      tesseract-ocr-eng genisoimage -y
+      tesseract-ocr-eng genisoimage vim net-tools screen -y
   ```
 
   This step may need to be adapted for your Linux distribution.

--- a/fetch-macOS-v2.py
+++ b/fetch-macOS-v2.py
@@ -221,7 +221,7 @@ def save_image(url, sess, filename='', directory=''):
     if filename.find('/') >= 0 or filename == '':
         raise RuntimeError('Invalid save path ' + filename)
 
-    print(f'Saving {url} to {directory}/{filename}...')
+    print(f'\nSaving {url} to {directory}/{filename}...')
 
     with open(os.path.join(directory, filename), 'wb') as fh:
         response = run_query(url, headers, raw=True)
@@ -229,9 +229,9 @@ def save_image(url, sess, filename='', directory=''):
         # print(total_size)
         if total_size < 1:
             total_size = response.headers['content-length']
-            print("Note: The total download size is %s bytes" % total_size)
+            print("\nNote: The total download size is %s bytes" % total_size)
         else:
-            print("Note: The total download size is %0.2f MB" % total_size)
+            print("\nNote: The total download size is %0.2f MB" % total_size)
         size = 0
         while True:
             chunk = response.read(2**20)
@@ -241,13 +241,13 @@ def save_image(url, sess, filename='', directory=''):
             size += len(chunk)
             print(f'\r{size / (2**20)} MBs downloaded...', end='')
             sys.stdout.flush()
-        print('\rDownload complete!\t\t\t\t\t')
+        print('\rDownload complete!' + ' ' * 20)
 
     return os.path.join(directory, os.path.basename(filename))
 
 
 def verify_image(dmgpath, cnkpath):
-    print('Verifying image with chunklist...')
+    print('\nVerifying image with chunklist...')
 
     with open(dmgpath, 'rb') as dmgf:
         cnkcount = 0
@@ -297,7 +297,7 @@ def action_download(args):
     info = get_image_info(session, bid=args.board_id, mlb=args.mlb, diag=args.diagnostics, os_type=args.os_type)
     if args.verbose:
         print(info)
-    print(f'Downloading {info[INFO_PRODUCT]}...')
+    print(f'\nDownloading {info[INFO_PRODUCT]}...')
     dmgname = '' if args.basename == '' else args.basename + '.dmg'
     dmgpath = save_image(info[INFO_IMAGE_LINK], info[INFO_IMAGE_SESS], dmgname, args.outdir)
     cnkname = '' if args.basename == '' else args.basename + '.chunklist'

--- a/notes.md
+++ b/notes.md
@@ -82,8 +82,8 @@ These steps will need to be adapted for your particular setup. A host machine
 with IOMMU support is required. Consult [this Arch Wiki article](https://wiki.archlinux.org/title/PCI_passthrough_via_OVMF)
 for general-purpose guidance and details.
 
-I am running Ubuntu 20.04.2 LTS on Intel i5-6500 + ASUS Z170-AR motherboard +
-AMD RX 570 GPU (May 2021).
+I am running Ubuntu 22.04.4 LTS on Intel i5-6500 + ASUS Z170-AR motherboard +
+AMD RX 6600 GPU (April 2024).
 
 - Blacklist the required kernel modules.
 
@@ -213,7 +213,8 @@ to dump the AMD GPU bios, and pass on to QEMU. This is especially required if
 your AMD GPU is not starting up properly (resulting in "no signal" on the
 monitor).
 
-Tested GPUs: ZOTAC GeForce GT 710 DDR3 (<= Big Sur), Sapphire Radeon RX 570.
+Tested GPUs: Sapphire AMD RX 6600 (RECOMMENDED!), ZOTAC GeForce GT 710 DDR3 (<=
+Big Sur), Sapphire Radeon RX 570.
 
 UPDATE: Project sponsors get access to the `Private OSX-KVM repository`, and
 direct support. This private repository has a playbook to automate 95% of this


### PR DESCRIPTION
The PR makes the logs more readable. Also, fixes a bug where the "Download complete !" line didn't display correctly.

**Before:**

```bash
1. High Sierra (10.13)
2. Mojave (10.14)
3. Catalina (10.15)
4. Big Sur (11.7)
5. Monterey (12.6)
6. Ventura (13) - RECOMMENDED
7. Sonoma (14) 

Choose a product to download (1-7): 6
Downloading 042-23155...
Saving http://oscdn.apple.com/content/downloads/28/14/042-23155/4rscm4lvp3084gutfgpkwj5eex0yyxmzkt/RecoveryImage/BaseSystem.dmg to ./BaseSystem.dmg...
Note: The total download size is 677.99 MB
Download complete!MBs downloaded...     		
Saving http://oscdn.apple.com/content/downloads/28/14/042-23155/4rscm4lvp3084gutfgpkwj5eex0yyxmzkt/RecoveryImage/BaseSystem.chunklist to ./BaseSystem.chunklist...
Note: The total download size is 2740 bytes
Download complete!25 MBs downloaded...  		
Verifying image with chunklist...
Image verification complete!
```

**After:**

```bash
1. High Sierra (10.13)
2. Mojave (10.14)
3. Catalina (10.15)
4. Big Sur (11.7)
5. Monterey (12.6)
6. Ventura (13) - RECOMMENDED
7. Sonoma (14) 

Choose a product to download (1-7): 6

Downloading 042-23155...

Saving http://oscdn.apple.com/content/downloads/28/14/042-23155/4rscm4lvp3084gutfgpkwj5eex0yyxmzkt/RecoveryImage/BaseSystem.dmg to ./BaseSystem.dmg...

Note: The total download size is 677.99 MB
Download complete!                    

Saving http://oscdn.apple.com/content/downloads/28/14/042-23155/4rscm4lvp3084gutfgpkwj5eex0yyxmzkt/RecoveryImage/BaseSystem.chunklist to ./BaseSystem.chunklist...

Note: The total download size is 2740 bytes
Download complete!                    

Verifying image with chunklist...
Image verification complete!
```