### PR TITLE
Automatically set the CPU type in shell scripts, and libvirt configs from fetch-macOS-v2.py

### DIFF
--- a/OpenCore/config.plist
+++ b/OpenCore/config.plist
@@ -1083,7 +1083,7 @@
 			<key>PasswordSalt</key>
 			<data></data>
 			<key>ScanPolicy</key>
-			<integer>0</integer>
+			<integer>17761027</integer>
 			<key>SecureBootModel</key>
 			<string>Disabled</string>
 			<key>Vault</key>
@@ -1795,7 +1795,7 @@
 			<key>ReplaceTabWithSpace</key>
 			<false/>
 			<key>Resolution</key>
-			<string>1344x840@32</string>
+			<string>1920x1080@32</string>
 			<key>SanitiseClearScreen</key>
 			<false/>
 			<key>TextRenderer</key>

--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ help (pull-requests!) with the following work items:
 
 ### Requirements
 
-* A modern Linux distribution. E.g. Ubuntu 22.04 LTS 64-bit or later.
+* A modern Linux distribution. E.g. Ubuntu 24.04 LTS 64-bit or later.
 
-* QEMU >= 6.2.0
+* QEMU >= 8.2.2
 
 * A CPU with Intel VT-x / AMD SVM support is required (`grep -e vmx -e svm /proc/cpuinfo`)
 
@@ -62,9 +62,9 @@ processors work just fine (even for macOS Sonoma).
 * Install QEMU and other packages.
 
   ```
-  sudo apt-get install qemu uml-utilities virt-manager git \
+  sudo apt-get install qemu-system uml-utilities virt-manager git \
       wget libguestfs-tools p7zip-full make dmg2img tesseract-ocr \
-      tesseract-ocr-eng genisoimage -y
+      tesseract-ocr-eng genisoimage vim net-tools screen -y
   ```
 
   This step may need to be adapted for your Linux distribution.
@@ -137,7 +137,7 @@ processors work just fine (even for macOS Sonoma).
   6. Ventura (13) - RECOMMENDED
   7. Sonoma (14)
 
-  Choose a product to download (1-6): 6
+  Choose a product to download (1-7): 6
   ```
 
   Note: Modern NVIDIA GPUs are supported on HighSierra but not on later

--- a/fetch-macOS-v2.py
+++ b/fetch-macOS-v2.py
@@ -17,6 +17,7 @@ pylint -> Your code has been rated at -0.08/10 ;(
 
 import argparse
 import binascii
+import glob
 import hashlib
 import json
 import linecache
@@ -469,6 +470,31 @@ def action_guess(args):
     print(f'UNKNOWN: Failed to determine supported models for MLB {mlb}!')
     return None
 
+def update_cpu(inputfile,product):
+   """ set the cpu type in the chosen file for Sonoma """
+   ocscript = inputfile
+   if product == 'sonoma':
+        newtype = "Haswell-noTSX"
+        oldtype = "Penryn"
+   else:
+            newtype = "Penryn"
+            oldtype = "Haswell-noTSX"
+   f = open(ocscript,'r')
+   filedata = f.read()
+   f.close()
+
+   newdata = filedata.replace(oldtype,newtype)
+
+   f = open(ocscript,'w')
+   f.write(newdata)
+   f.close()
+
+def update_scripts(product):
+    """ update the cpu type in supporting scripts for Sonoma """
+    for bash_script in glob.iglob('**/*.sh', recursive=True):
+        update_cpu(bash_script,product)
+    for libvirt_config in glob.iglob('**/*libvirt*.xml', recursive=True):
+        update_cpu(libvirt_config,product)
 
 # https://stackoverflow.com/questions/2280334/shortest-way-of-creating-an-object-with-arbitrary-attributes-in-python
 class gdata:
@@ -558,7 +584,17 @@ def main():
         os_type = "default"
     args = gdata(mlb = product["m"], board_id = product["b"], diagnostics =
             False, os_type = os_type, verbose=False, basename="", outdir=".")
-    action_download(args)
+    update_scripts(product['short'])
+#    if product['short'] == 'sonoma':
+#        with open("OpenCore-Boot.sh", "w") as OCScript:
+#            scriptdata = OCScript.read()
+#            scriptdata = scriptdata.replace('Penryn', 'Haswell-noTSX')
+#        with open('OpenCore-Boot.sh', 'w') as OCScript:
+#            OCScript.write(scriptdata)
+#    else:
+#        with open("Output.txt", "w") as text_file:
+#            text_file.write('DERP')
+    #action_download(args)
 
 
 if __name__ == '__main__':

--- a/notes.md
+++ b/notes.md
@@ -82,8 +82,8 @@ These steps will need to be adapted for your particular setup. A host machine
 with IOMMU support is required. Consult [this Arch Wiki article](https://wiki.archlinux.org/title/PCI_passthrough_via_OVMF)
 for general-purpose guidance and details.
 
-I am running Ubuntu 20.04.2 LTS on Intel i5-6500 + ASUS Z170-AR motherboard +
-AMD RX 570 GPU (May 2021).
+I am running Ubuntu 22.04.4 LTS on Intel i5-6500 + ASUS Z170-AR motherboard +
+AMD RX 6600 GPU (April 2024).
 
 - Blacklist the required kernel modules.
 
@@ -213,7 +213,8 @@ to dump the AMD GPU bios, and pass on to QEMU. This is especially required if
 your AMD GPU is not starting up properly (resulting in "no signal" on the
 monitor).
 
-Tested GPUs: ZOTAC GeForce GT 710 DDR3 (<= Big Sur), Sapphire Radeon RX 570.
+Tested GPUs: Sapphire AMD RX 6600 (RECOMMENDED!), ZOTAC GeForce GT 710 DDR3 (<=
+Big Sur), Sapphire Radeon RX 570.
 
 UPDATE: Project sponsors get access to the `Private OSX-KVM repository`, and
 direct support. This private repository has a playbook to automate 95% of this


### PR DESCRIPTION
fetch-macOS-v2.py will automatically set the CPU type in each shell script, and xml libvirt config (with the string 'libvirt' in its file name)
This is just a bit handier than manually defining it. More importantly its one less thing to remember.