### PR TITLE
Use `ip` instead of `brctl`

### DIFF
--- a/networking-qemu-kvm-howto.txt
+++ b/networking-qemu-kvm-howto.txt
@@ -61,7 +61,7 @@ sudo apt-get install uml-utilities virt-manager
 
 sudo ip tuntap add dev tap0 mode tap
 sudo ip link set tap0 up promisc on
-sudo brctl addif virbr0 tap0
+sudo ip link set dev tap0 master virbr0
 
 sudo ip link set dev virbr0 up  # as needed
 sudo ip link set dev tap0 master virbr0


### PR DESCRIPTION
This is the last item using `brctl`, and we can just as easily replace it with the equivalent `ip` incantation.