### PR TITLE
Enable TRIM support for the macOS hard drive image.

### DIFF
--- a/OpenCore-Boot.sh
+++ b/OpenCore-Boot.sh
@@ -57,7 +57,7 @@ args=(
   -device ide-hd,bus=sata.3,drive=InstallMedia
   -drive id=InstallMedia,if=none,file="$REPO_PATH/BaseSystem.img",format=raw
   -drive id=MacHDD,if=none,file="$REPO_PATH/mac_hdd_ng.img",format=qcow2
-  -device ide-hd,bus=sata.4,drive=MacHDD
+  -device ide-hd,bus=sata.4,drive=MacHDD,rotation_rate=1
   # -netdev tap,id=net0,ifname=tap0,script=no,downscript=no -device virtio-net-pci,netdev=net0,id=net0,mac=52:54:00:c9:18:27
   -netdev user,id=net0,hostfwd=tcp::2222-:22 -device virtio-net-pci,netdev=net0,id=net0,mac=52:54:00:c9:18:27
   # -netdev user,id=net0 -device vmxnet3,netdev=net0,id=net0,mac=52:54:00:c9:18:27  # Note: Use this line for High Sierra

--- a/README.md
+++ b/README.md
@@ -235,6 +235,8 @@ work, patience, and a bit of luck (perhaps?).
 
 ### Post-Installation
 
+* Run `sudo trimforce enable` to enable TRIM support on the macOS hard drive.
+
 * See [networking notes](networking-qemu-kvm-howto.txt) on how to setup networking in your VM, outbound and also inbound for remote access to your VM via SSH, VNC, etc.
 
 * To passthrough GPUs and other devices, see [these notes](notes.md#gpu-passthrough-notes).

--- a/macOS-libvirt-Catalina.xml
+++ b/macOS-libvirt-Catalina.xml
@@ -70,7 +70,7 @@
     <disk type='file' device='disk'>
       <driver name='qemu' type='qcow2' cache='writeback' io='threads'/>
       <source file='/home/CHANGEME/OSX-KVM/mac_hdd_ng.img'/>
-      <target dev='sdb' bus='sata'/>
+      <target dev='sdb' bus='sata' rotation_rate='1'/>
       <boot order='1'/>
       <address type='drive' controller='0' bus='0' target='0' unit='1'/>
     </disk>


### PR DESCRIPTION
We need to tell macOS the emulated drive is an SSD *and* run `trimforce enable` in the guest because we can't emulate a specific (i.e. Apple-approved) drive.