### PR TITLE
updated nixpkgs version to nixpkgs-unstable

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1717179513,
-        "narHash": "sha256-vboIEwIQojofItm2xGCdZCzW96U85l9nDW3ifMuAIdM=",
+        "lastModified": 1746152631,
+        "narHash": "sha256-zBuvmL6+CUsk2J8GINpyy8Hs1Zp4PP6iBWSmZ4SCQ/s=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "63dacb46bf939521bdc93981b4cbb7ecb58427a0",
+        "rev": "032bc6539bd5f14e9d0c51bd79cfe9a055b094c3",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "24.05",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/24.05";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
   inputs.flake-utils.url = "github:numtide/flake-utils";
 


### PR DESCRIPTION
I noticed the following error when running `./OpenCore-Boot.sh`:

```
qemu-system-x86_64: symbol lookup error: /nix/store/2kc4szkd8zq6vc2vczs1770n4x8rybqk-pipewire-1.4.1-jack/lib/libjack.so.0: undefined symbol: pw_log_topic_register
```

Updating the nixpkgs flake input to nixpkgs-unstable resolved the issue.

I run NixOS with pipewire-jack. I installed all dependencies with direnv. I am happy to share parts of my config if desired. 

MacOS version: Sonoma