### PR TITLE
Add builder command using nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,9 +142,16 @@ processors work just fine (even for macOS Sonoma).
 
   Choose a product to download (1-9): 7
   ```
-
   Note: Modern NVIDIA GPUs are supported on HighSierra but not on later
   versions of macOS.
+
+* Or simple Nix Builder.
+
+  ```
+  nix run github:FBIGlowie/OSX-KVM/ --no-write-lock-file -- catalina
+  ```
+  This will clone a repository at `./OSX-KVM`, give it the right permissions,
+  and automatically start `./OpenCore-Boot.sh`.
 
 * Convert the downloaded `BaseSystem.dmg` file into the `BaseSystem.img` file.
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ processors work just fine (even for macOS Sonoma).
 * Or use a simple nix command if you have it installed.
 
   ```
-  nix run github:FBIGlowie/OSX-KVM/ --no-write-lock-file -- catalina
+  nix run github:kholia/OSX-KVM/ --no-write-lock-file -- catalina
   ```
   This will clone a repository at `./OSX-KVM`, download the image,
   give everything the right permissions, and start `./OpenCore-Boot.sh`.

--- a/README.md
+++ b/README.md
@@ -166,8 +166,8 @@ processors work just fine (even for macOS Sonoma).
   ```
   nix run github:FBIGlowie/OSX-KVM/ --no-write-lock-file -- catalina
   ```
-  This will clone a repository at `./OSX-KVM`, give it the right permissions,
-  and automatically start `./OpenCore-Boot.sh`.
+  This will clone a repository at `./OSX-KVM`, download the image,
+  give everything the right permissions, and start `./OpenCore-Boot.sh`.
 
 * Now you are ready to install macOS 🚀
 

--- a/README.md
+++ b/README.md
@@ -145,14 +145,6 @@ processors work just fine (even for macOS Sonoma).
   Note: Modern NVIDIA GPUs are supported on HighSierra but not on later
   versions of macOS.
 
-* Or simple Nix Builder.
-
-  ```
-  nix run github:FBIGlowie/OSX-KVM/ --no-write-lock-file -- catalina
-  ```
-  This will clone a repository at `./OSX-KVM`, give it the right permissions,
-  and automatically start `./OpenCore-Boot.sh`.
-
 * Convert the downloaded `BaseSystem.dmg` file into the `BaseSystem.img` file.
 
   ```
@@ -168,6 +160,14 @@ processors work just fine (even for macOS Sonoma).
   ```
 
   NOTE: Create this HDD image file on a fast SSD/NVMe disk for best results.
+
+* Or simple Nix Builder.
+
+  ```
+  nix run github:FBIGlowie/OSX-KVM/ --no-write-lock-file -- catalina
+  ```
+  This will clone a repository at `./OSX-KVM`, give it the right permissions,
+  and automatically start `./OpenCore-Boot.sh`.
 
 * Now you are ready to install macOS 🚀
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ processors work just fine (even for macOS Sonoma).
 
   NOTE: Create this HDD image file on a fast SSD/NVMe disk for best results.
 
-* Or simple Nix Builder.
+* Or use a simple nix command if you have it installed.
 
   ```
   nix run github:FBIGlowie/OSX-KVM/ --no-write-lock-file -- catalina

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,6 @@
   inputs.nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
 
   inputs.flake-utils.url = "github:numtide/flake-utils";
-  inputs.OSX-KVM.flake = false;
 
   outputs =
     { self

--- a/flake.nix
+++ b/flake.nix
@@ -2,6 +2,7 @@
   inputs.nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
 
   inputs.flake-utils.url = "github:numtide/flake-utils";
+  inputs.OSX-KVM.flake = false;
 
   outputs =
     { self


### PR DESCRIPTION
This PR sets to add a app to the flake that allows the automatic downloading of the image with one simple command, which is described in the README.

The command would be:
```
nix run github:kholia/OSX-KVM/ --no-write-lock-file -- catalina
```

For testing, here is the command from my fork:
```
nix run github:FBIGlowie/OSX-KVM/ --no-write-lock-file -- catalina
```